### PR TITLE
Make it run on M1 (neon) macos machines

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest-xlarge]
         rust:
           - stable
           - beta


### PR DESCRIPTION
This PR modifies the CI to test arroy on an M1 macos machine.