### PR TITLE
Make sure we always build at least one tree

### DIFF
--- a/src/tests/writer.rs
+++ b/src/tests/writer.rs
@@ -44,6 +44,25 @@ fn use_u32_max_for_a_vec() {
 }
 
 #[test]
+fn write_one_vector() {
+    let handle = create_database::<Euclidean>();
+    let mut wtxn = handle.env.write_txn().unwrap();
+    let writer = Writer::prepare(&mut wtxn, handle.database, 0, 3).unwrap();
+    writer.add_item(&mut wtxn, 0, &[0.0, 1.0, 2.0]).unwrap();
+
+    writer.build(&mut wtxn, &mut rng(), None).unwrap();
+    wtxn.commit().unwrap();
+
+    insta::assert_display_snapshot!(handle, @r###"
+    ==================
+    Dumping index 0
+    Item 0: Leaf(Leaf { header: NodeHeaderAngular { norm: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
+    Tree 0: Descendants(Descendants { descendants: [0] })
+    Root: Metadata { dimensions: 3, n_items: 1, roots: [0], distance: "euclidean" }
+    "###);
+}
+
+#[test]
 fn write_one_vector_in_one_tree() {
     let handle = create_database::<Euclidean>();
     let mut wtxn = handle.env.write_txn().unwrap();

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -235,7 +235,7 @@ impl<D: Distance> Writer<D> {
                 // but continue to generate trees if the number of trees is specified
                 .take_any_while(|_| match n_trees {
                     Some(_) => true,
-                    None => concurrent_node_ids.current() < (self.n_items - 1).max(1),
+                    None => concurrent_node_ids.current() < self.n_items,
                 })
                 .map(|(i, seed)| {
                     log::debug!("started generating tree {i:X}...");

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -235,7 +235,7 @@ impl<D: Distance> Writer<D> {
                 // but continue to generate trees if the number of trees is specified
                 .take_any_while(|_| match n_trees {
                     Some(_) => true,
-                    None => concurrent_node_ids.current() < (self.n_items - 1),
+                    None => concurrent_node_ids.current() < (self.n_items - 1).max(1),
                 })
                 .map(|(i, seed)| {
                     log::debug!("started generating tree {i:X}...");


### PR DESCRIPTION
# Pull Request

Previously `arroy` will return an empty vector when a DB contains only a single element.
This is an indexing bug. We now force the number of trees to be at least 1.

Related Meilisearch PR: https://github.com/meilisearch/meilisearch/pull/4296
