### PR TITLE
Add a test to check if Writer::clear works

### DIFF
--- a/src/tests/writer.rs
+++ b/src/tests/writer.rs
@@ -4,7 +4,7 @@ use rand::Rng;
 
 use super::{create_database, rng};
 use crate::distance::{DotProduct, Euclidean};
-use crate::{Database, Writer};
+use crate::{Database, Reader, Writer};
 
 #[test]
 fn clear_small_database() {
@@ -15,15 +15,23 @@ fn clear_small_database() {
 
     let mut wtxn = env.write_txn().unwrap();
     let database: Database<DotProduct> = env.create_database(&mut wtxn, None).unwrap();
-    let writer = Writer::new(database, 0, 3);
-    writer.add_item(&mut wtxn, 0, &[0.0, 1.0, 2.0]).unwrap();
-    writer.clear(&mut wtxn).unwrap();
-    writer.build(&mut wtxn, &mut rng(), None).unwrap();
+
+    let zero_writer = Writer::new(database, 0, 3);
+    zero_writer.add_item(&mut wtxn, 0, &[0.0, 1.0, 2.0]).unwrap();
+    zero_writer.clear(&mut wtxn).unwrap();
+    zero_writer.build(&mut wtxn, &mut rng(), None).unwrap();
+
+    let one_writer = Writer::new(database, 1, 3);
+    one_writer.add_item(&mut wtxn, 0, &[1.0, 2.0, 3.0]).unwrap();
+    one_writer.build(&mut wtxn, &mut rng(), None).unwrap();
     wtxn.commit().unwrap();
 
     let mut wtxn = env.write_txn().unwrap();
-    let writer = Writer::new(database, 0, 3);
-    writer.clear(&mut wtxn).unwrap();
+    let zero_writer = Writer::new(database, 0, 3);
+    zero_writer.clear(&mut wtxn).unwrap();
+
+    let one_reader = Reader::open(&wtxn, 1, database).unwrap();
+    assert_eq!(one_reader.item_vector(&wtxn, 0).unwrap().unwrap(), vec![1.0, 2.0, 3.0]);
     wtxn.commit().unwrap();
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -205,7 +205,7 @@ impl<D: Distance> Writer<D> {
             .database
             .remap_key_type::<PrefixCodec>()
             .prefix_iter_mut(wtxn, &Prefix::all(self.index))?
-            .remap_key_type::<DecodeIgnore>();
+            .remap_types::<DecodeIgnore, DecodeIgnore>();
 
         while let Some((_id, _node)) = cursor.next().transpose()? {
             // safety: we don't have any reference to the database


### PR DESCRIPTION
The PR fixes #65 by ignoring the value/data when we iterate through the database subset entries to clear a database. It was previously trying to read the entries by using the `NodeCodec<D: Distance>` and wasn't able to deserialize some metadata entries.