### PR TITLE
Fix panic at search when the index is empty

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -203,6 +203,9 @@ impl<'t, D: Distance> Reader<'t, D> {
         search_k: Option<NonZeroUsize>,
         candidates: Option<&RoaringBitmap>,
     ) -> Result<Vec<(ItemId, f32)>> {
+        if self.items.is_empty() {
+            return Ok(Vec::new());
+        }
         // Since the datastructure describes a kind of btree, the capacity is something in the order of:
         // The number of root nodes + log2 of the total number of vectors.
         let mut queue =


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #75 

## What does this PR do?
- Check if the index is empty before doing a `ilog2` that only works on `>0` values
- Add a test