### PR TITLE
Panic at search when the trees need a rebuild

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "arroy"
 description = "Annoy-inspired Approximate Nearest Neighbors in Rust, based on LMDB and optimized for memory usage"
-version = "0.3.1"
+version = "0.4.0"
 documentation = "https://docs.rs/arroy"
 repository = "https://github.com/meilisearch/arroy"
 keywords = ["ANN-search", "Graph-algorithms", "Vector-Search", "Store"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     Io(#[from] io::Error),
 
     /// The user is trying to insert or search for a vector that is not of the right dimensions.
-    #[error("Invalid vector dimensions. Got {received} but expected {expected}.")]
+    #[error("Invalid vector dimensions. Got {received} but expected {expected}")]
     InvalidVecDimension {
         /// The expected number of dimensions.
         expected: usize,
@@ -23,7 +23,7 @@ pub enum Error {
     },
 
     /// An internal error returned when arroy cannot generate internal IDs.
-    #[error("Database full. Arroy cannot generate enough internal IDs for your items.")]
+    #[error("Database full. Arroy cannot generate enough internal IDs for your items")]
     DatabaseFull,
 
     /// The user tried to append an item in the database but the last inserted item
@@ -32,7 +32,7 @@ pub enum Error {
     InvalidItemAppend,
 
     /// The user is trying to query a database with a distance that is not of the right type.
-    #[error("Invalid distance provided. Got {received} but expected {expected}.")]
+    #[error("Invalid distance provided. Got {received} but expected {expected}")]
     UnmatchingDistance {
         /// The expected distance type.
         expected: String,
@@ -43,15 +43,15 @@ pub enum Error {
     /// Arroy is not able to find the metadata for a given index.
     /// It is probably because the user forget to build the database.
     #[error(
-        "Metadata are missing on index {0}, did you build your database before trying to read it."
+        "Metadata are missing on index {0}, did you build your database before trying to read it"
     )]
     MissingMetadata(u16),
 
     /// The last time items in the database were updated, the [`Writer::build`] method wasn't called.
-    #[error("The trees have not been built after an update on index {0}.")]
+    #[error("The trees have not been built after an update on index {0}")]
     NeedBuild(u16),
 
     /// Internal error
-    #[error("Internal error: {:?} is missing in index `{}`.", .0.node, .0.index)]
+    #[error("Internal error: {:?} is missing in index `{}`", .0.node, .0.index)]
     MissingKey(Key),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use crate::key::Key;
+use crate::{key::Key, node_id::NodeMode, ItemId};
 
 /// The different set of errors that arroy can encounter.
 #[derive(Debug, thiserror::Error)]
@@ -52,6 +52,27 @@ pub enum Error {
     NeedBuild(u16),
 
     /// Internal error
-    #[error("Internal error: {:?} is missing in index `{}`", .0.node, .0.index)]
-    MissingKey(Key),
+    #[error("Internal error: {mode}({item}) is missing in index `{index}`")]
+    MissingKey {
+        /// The index that caused the error
+        index: u16,
+        /// The kind of item that was being queried
+        mode: &'static str,
+        /// The item ID queried
+        item: ItemId,
+    },
+}
+
+impl Error {
+    pub(crate) fn missing_key(key: Key) -> Self {
+        Self::MissingKey {
+            index: key.index,
+            mode: match key.node.mode {
+                NodeMode::Item => "Item",
+                NodeMode::Tree => "Tree",
+                NodeMode::Metadata => "Metadata",
+            },
+            item: key.node.item,
+        }
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use std::io;
 
+use crate::key::Key;
+
 /// The different set of errors that arroy can encounter.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -50,6 +52,6 @@ pub enum Error {
     NeedBuild(u16),
 
     /// Internal error
-    #[error("Internal error: Node is missing")]
-    MissingNode,
+    #[error("Internal error: {:?} is missing in index `{}`.", .0.node, .0.index)]
+    MissingKey(Key),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ pub enum Error {
     /// Arroy is not able to find the metadata for a given index.
     /// It is probably because the user forget to build the database.
     #[error(
-        "Metadata are missing on index {0}, did you build your database before trying to read it"
+        "Metadata are missing on index {0}, You must build your database before attempting to read it"
     )]
     MissingMetadata(u16),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,8 +40,14 @@ pub enum Error {
 
     /// Arroy is not able to find the metadata for a given index.
     /// It is probably because the user forget to build the database.
-    #[error("Metadata are missing, did you build your database before trying to read it.")]
-    MissingMetadata,
+    #[error(
+        "Metadata are missing on index {0}, did you build your database before trying to read it."
+    )]
+    MissingMetadata(u16),
+
+    /// The last time items in the database were updated, the [`Writer::build`] method wasn't called.
+    #[error("The trees have not been built after an update on index {0}.")]
+    NeedBuild(u16),
 
     /// Internal error
     #[error("Internal error: Node is missing")]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -227,7 +227,8 @@ impl<'t, D: Distance> Reader<'t, D> {
                 None => break,
             };
 
-            match self.database.get(rtxn, &Key::new(self.index, item))?.unwrap() {
+            let key = Key::new(self.index, item);
+            match self.database.get(rtxn, &key)?.ok_or(Error::MissingKey(key))? {
                 Node::Leaf(_) => {
                     if candidates.map_or(true, |c| c.contains(item.item)) {
                         nns.push(item.unwrap_item());
@@ -255,7 +256,8 @@ impl<'t, D: Distance> Reader<'t, D> {
 
         let mut nns_distances = Vec::with_capacity(nns.len());
         for nn in nns {
-            let leaf = match self.database.get(rtxn, &Key::item(self.index, nn))?.unwrap() {
+            let key = Key::item(self.index, nn);
+            let leaf = match self.database.get(rtxn, &key)?.ok_or(Error::MissingKey(key))? {
                 Node::Leaf(leaf) => leaf,
                 Node::Descendants(_) | Node::SplitPlaneNormal(_) => unreachable!(),
             };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -45,9 +45,7 @@ impl<'t, D: Distance> Reader<'t, D> {
                 received: D::name(),
             });
         }
-        let need_build =
-            database.remap_data_type::<Bytes>().get(rtxn, &Key::updated(index))?.is_some();
-        if need_build {
+        if database.remap_data_type::<Bytes>().get(rtxn, &Key::updated(index))?.is_some() {
             return Err(Error::NeedBuild(index));
         }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -228,7 +228,7 @@ impl<'t, D: Distance> Reader<'t, D> {
             };
 
             let key = Key::new(self.index, item);
-            match self.database.get(rtxn, &key)?.ok_or(Error::MissingKey(key))? {
+            match self.database.get(rtxn, &key)?.ok_or(Error::missing_key(key))? {
                 Node::Leaf(_) => {
                     if candidates.map_or(true, |c| c.contains(item.item)) {
                         nns.push(item.unwrap_item());
@@ -257,7 +257,7 @@ impl<'t, D: Distance> Reader<'t, D> {
         let mut nns_distances = Vec::with_capacity(nns.len());
         for nn in nns {
             let key = Key::item(self.index, nn);
-            let leaf = match self.database.get(rtxn, &key)?.ok_or(Error::MissingKey(key))? {
+            let leaf = match self.database.get(rtxn, &key)?.ok_or(Error::missing_key(key))? {
                 Node::Leaf(leaf) => leaf,
                 Node::Descendants(_) | Node::SplitPlaneNormal(_) => unreachable!(),
             };

--- a/src/tests/reader.rs
+++ b/src/tests/reader.rs
@@ -34,7 +34,7 @@ fn open_unfinished_db() {
 
     let rtxn = handle.env.read_txn().unwrap();
     let ret = Reader::<Euclidean>::open(&rtxn, 0, handle.database).map(|_| ()).unwrap_err();
-    insta::assert_display_snapshot!(ret, @"Metadata are missing, did you build your database before trying to read it.");
+    insta::assert_display_snapshot!(ret, @"Metadata are missing on index 0, did you build your database before trying to read it.");
 }
 
 #[test]
@@ -206,7 +206,7 @@ fn filtering() {
 
 #[test]
 fn search_in_empty_database() {
-    // See https://github.com/meilisearch/arroy/issues/74
+    // See https://github.com/meilisearch/arroy/issues/75
     let handle = create_database::<Euclidean>();
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -218,4 +218,42 @@ fn search_in_empty_database() {
     let reader = Reader::open(&rtxn, 0, handle.database).unwrap();
     let ret = reader.nns_by_vector(&rtxn, &[0., 0.], 10, None, None).unwrap();
     insta::assert_debug_snapshot!(ret, @"[]");
+}
+
+#[test]
+fn try_reading_in_a_non_built_database() {
+    // See https://github.com/meilisearch/arroy/issues/74
+    let handle = create_database::<Euclidean>();
+
+    let mut wtxn = handle.env.write_txn().unwrap();
+    let writer = Writer::new(handle.database, 0, 2);
+    writer.add_item(&mut wtxn, 0, &[0.0, 0.0]).unwrap();
+    // We don't build the database
+    wtxn.commit().unwrap();
+
+    let rtxn = handle.env.read_txn().unwrap();
+    let error = Reader::open(&rtxn, 0, handle.database).unwrap_err();
+    insta::assert_debug_snapshot!(error, @r###"
+    MissingMetadata(
+        0,
+    )
+    "###);
+    drop(rtxn);
+
+    // we build the database once to get valid metadata
+    let mut wtxn = handle.env.write_txn().unwrap();
+    let writer = Writer::new(handle.database, 0, 2);
+    writer.build(&mut wtxn, &mut rng(), None).unwrap();
+    let writer = Writer::new(handle.database, 0, 2);
+    writer.del_item(&mut wtxn, 0).unwrap();
+    // We don't build the database; this leaves the database in a corrupted state
+    wtxn.commit().unwrap();
+
+    let rtxn = handle.env.read_txn().unwrap();
+    let error = Reader::open(&rtxn, 0, handle.database).unwrap_err();
+    insta::assert_debug_snapshot!(error, @r###"
+    NeedBuild(
+        0,
+    )
+    "###);
 }

--- a/src/tests/reader.rs
+++ b/src/tests/reader.rs
@@ -34,7 +34,7 @@ fn open_unfinished_db() {
 
     let rtxn = handle.env.read_txn().unwrap();
     let ret = Reader::<Euclidean>::open(&rtxn, 0, handle.database).map(|_| ()).unwrap_err();
-    insta::assert_display_snapshot!(ret, @"Metadata are missing on index 0, did you build your database before trying to read it.");
+    insta::assert_display_snapshot!(ret, @"Metadata are missing on index 0, did you build your database before trying to read it");
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn open_db_with_wrong_dimension() {
     let rtxn = handle.env.read_txn().unwrap();
     let reader = Reader::<Euclidean>::open(&rtxn, 0, handle.database).unwrap();
     let ret = reader.nns_by_vector(&rtxn, &[1.0, 2.0, 3.0], 5, None, None).unwrap_err();
-    insta::assert_display_snapshot!(ret, @"Invalid vector dimensions. Got 3 but expected 2.");
+    insta::assert_display_snapshot!(ret, @"Invalid vector dimensions. Got 3 but expected 2");
 }
 
 #[test]

--- a/src/tests/reader.rs
+++ b/src/tests/reader.rs
@@ -34,7 +34,7 @@ fn open_unfinished_db() {
 
     let rtxn = handle.env.read_txn().unwrap();
     let ret = Reader::<Euclidean>::open(&rtxn, 0, handle.database).map(|_| ()).unwrap_err();
-    insta::assert_display_snapshot!(ret, @"Metadata are missing on index 0, did you build your database before trying to read it");
+    insta::assert_display_snapshot!(ret, @"Metadata are missing on index 0, You must build your database before attempting to read it");
 }
 
 #[test]

--- a/src/tests/snapshots/arroy__tests__writer__write_and_update_lot_of_random_points-2.snap
+++ b/src/tests/snapshots/arroy__tests__writer__write_and_update_lot_of_random_points-2.snap
@@ -213,5 +213,4 @@ Tree 124: Descendants(Descendants { descendants: [14, 16, 22, 38, 41, 42, 43, 44
 Tree 125: Descendants(Descendants { descendants: [2, 10, 21, 23, 26, 28, 29, 30, 34, 37, 39, 47, 52, 54, 55, 67, 68, 69, 71, 72, 76, 78, 86, 88, 90, 94, 97, 98] })
 Tree 126: SplitPlaneNormal(SplitPlaneNormal { left: Tree(124), right: Tree(125), normal: [-0.2156, 0.0925, 0.0242, 0.1246, -0.0758, -0.0672, -0.1816, 0.4853, 0.1643, 0.1418, 0.2752, -0.1825, -0.2671, 0.0674, -0.1950, -0.0743, -0.1493, -0.0368, -0.1929, 0.2540, -0.0441, 0.3135, -0.2219, 0.1059, 0.2115, 0.0749, 0.1629, -0.1050, -0.0211, 0.0051] })
 Root: Metadata { dimensions: 30, items: RoaringBitmap<100 values between 0 and 99>, roots: [8, 17, 24, 35, 44, 55, 64, 75, 86, 97], distance: "euclidean" }
-updated_item_ids: RoaringBitmap<[]>
 

--- a/src/tests/snapshots/arroy__tests__writer__write_and_update_lot_of_random_points.snap
+++ b/src/tests/snapshots/arroy__tests__writer__write_and_update_lot_of_random_points.snap
@@ -203,5 +203,4 @@ Tree 95: SplitPlaneNormal(SplitPlaneNormal { left: Tree(89), right: Tree(94), no
 Tree 96: SplitPlaneNormal(SplitPlaneNormal { left: Tree(88), right: Tree(95), normal: [0.0684, -0.2434, -0.1543, 0.0337, 0.1784, 0.1295, 0.3061, -0.0175, -0.0679, -0.1419, -0.0180, 0.2335, 0.3782, -0.1127, 0.2746, -0.2657, -0.0579, 0.1808, 0.2623, -0.3329, 0.1801, -0.2106, 0.1692, -0.1191, 0.0152, 0.1214, 0.0252, -0.0236, -0.1220, -0.1448] })
 Tree 97: SplitPlaneNormal(SplitPlaneNormal { left: Tree(87), right: Tree(96), normal: [-0.0316, -0.1036, 0.3252, -0.0985, -0.1286, -0.4867, -0.0286, 0.1159, -0.0177, 0.2205, 0.0177, 0.3192, 0.1521, -0.1484, 0.1918, -0.2794, -0.1141, 0.2598, 0.1453, 0.1133, -0.1149, -0.0455, 0.0697, -0.2537, 0.1797, -0.0423, -0.0470, 0.0886, 0.0868, 0.2083] })
 Root: Metadata { dimensions: 30, items: RoaringBitmap<100 values between 0 and 99>, roots: [8, 17, 24, 35, 44, 55, 64, 75, 86, 97], distance: "euclidean" }
-updated_item_ids: RoaringBitmap<[]>
 

--- a/src/tests/writer.rs
+++ b/src/tests/writer.rs
@@ -52,7 +52,6 @@ fn use_u32_max_minus_one_for_a_vec() {
     Item 4294967294: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     Tree 0: Descendants(Descendants { descendants: [4294967294] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[4294967294]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -72,7 +71,6 @@ fn use_u32_max_for_a_vec() {
     Item 4294967295: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     Tree 0: Descendants(Descendants { descendants: [4294967295] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[4294967295]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -92,12 +90,12 @@ fn write_one_vector() {
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
 #[test]
 fn write_one_vector_in_one_tree() {
+    let _ = env_logger::builder().is_test(true).parse_filters("trace").try_init();
     let handle = create_database::<Euclidean>();
     let mut wtxn = handle.env.write_txn().unwrap();
     let writer = Writer::new(handle.database, 0, 3);
@@ -112,7 +110,6 @@ fn write_one_vector_in_one_tree() {
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -132,7 +129,6 @@ fn write_one_vector_in_multiple_trees() {
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -158,7 +154,6 @@ fn write_vectors_until_there_is_a_descendants() {
     Item 2: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [2.0000, 2.0000, 2.0000] })
     Tree 0: Descendants(Descendants { descendants: [0, 1, 2] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0, 1, 2]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -186,7 +181,6 @@ fn write_vectors_until_there_is_a_split() {
     Tree 0: Descendants(Descendants { descendants: [1, 2, 3] })
     Tree 1: SplitPlaneNormal(SplitPlaneNormal { left: Tree(0), right: Item(0), normal: [-0.5774, -0.5774, -0.5774] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0, 1, 2, 3]>, roots: [1], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -235,31 +229,26 @@ fn write_multiple_indexes() {
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     ==================
     Dumping index 1
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     ==================
     Dumping index 2
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     ==================
     Dumping index 3
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     ==================
     Dumping index 4
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -313,7 +302,6 @@ fn overwrite_one_item_incremental() {
     Tree 3: SplitPlaneNormal(SplitPlaneNormal { left: Tree(1), right: Tree(2), normal: [0.0000, 0.0000] })
     Tree 4: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(3), normal: [1.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 3, 4, 5]>, roots: [4], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -340,7 +328,6 @@ fn overwrite_one_item_incremental() {
     Tree 4: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(3), normal: [1.0000, 0.0000] })
     Tree 5: Descendants(Descendants { descendants: [2, 3] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 3, 4, 5]>, roots: [4], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -361,7 +348,6 @@ fn delete_one_item_in_a_one_item_db() {
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -376,8 +362,65 @@ fn delete_one_item_in_a_one_item_db() {
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[]>, roots: [], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
+
+    let rtxn = handle.env.read_txn().unwrap();
+    let one_reader = Reader::open(&rtxn, 0, handle.database).unwrap();
+    assert!(one_reader.item_vector(&rtxn, 0).unwrap().is_none());
+}
+
+#[test]
+fn delete_document_in_an_empty_index_74() {
+    // See https://github.com/meilisearch/arroy/issues/74
+    let handle = create_database::<Euclidean>();
+    let mut rng = rng();
+    let mut wtxn = handle.env.write_txn().unwrap();
+
+    let writer = Writer::new(handle.database, 0, 2);
+    writer.del_item(&mut wtxn, 0).unwrap();
+    writer.add_item(&mut wtxn, 0, &[0., 0.]).unwrap();
+    writer.build(&mut wtxn, &mut rng, None).unwrap();
+
+    wtxn.commit().unwrap();
+
+    insta::assert_display_snapshot!(handle, @r###"
+    ==================
+    Dumping index 0
+    Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
+    Tree 0: Descendants(Descendants { descendants: [0] })
+    Root: Metadata { dimensions: 2, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
+    "###);
+
+    let mut wtxn = handle.env.write_txn().unwrap();
+
+    let writer1 = Writer::new(handle.database, 0, 2);
+    writer1.del_item(&mut wtxn, 0).unwrap();
+
+    let writer2 = Writer::new(handle.database, 1, 2);
+    writer2.del_item(&mut wtxn, 0).unwrap();
+
+    writer1.build(&mut wtxn, &mut rng, None).unwrap();
+    writer2.build(&mut wtxn, &mut rng, None).unwrap();
+
+    let reader = Reader::open(&wtxn, 1, handle.database).unwrap();
+    let ret = reader.nns_by_vector(&wtxn, &[0., 0.], 10, None, None).unwrap();
+    insta::assert_debug_snapshot!(ret, @"[]");
+
+    wtxn.commit().unwrap();
+
+    insta::assert_display_snapshot!(handle, @r###"
+    ==================
+    Dumping index 0
+    Root: Metadata { dimensions: 2, items: RoaringBitmap<[]>, roots: [], distance: "euclidean" }
+    ==================
+    Dumping index 1
+    Root: Metadata { dimensions: 2, items: RoaringBitmap<[]>, roots: [], distance: "euclidean" }
+    "###);
+
+    let rtxn = handle.env.read_txn().unwrap();
+    let reader = Reader::open(&rtxn, 1, handle.database).unwrap();
+    let ret = reader.nns_by_vector(&rtxn, &[0., 0.], 10, None, None).unwrap();
+    insta::assert_debug_snapshot!(ret, @"[]");
 }
 
 #[test]
@@ -400,7 +443,6 @@ fn delete_one_item_in_a_descendant() {
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [1.0000, 0.0000] })
     Tree 0: Descendants(Descendants { descendants: [0, 1] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -417,7 +459,6 @@ fn delete_one_item_in_a_descendant() {
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [1.0000, 0.0000] })
     Tree 0: Descendants(Descendants { descendants: [1] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[1]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -444,7 +485,6 @@ fn delete_one_leaf_in_a_split() {
     Tree 0: Descendants(Descendants { descendants: [1, 2] })
     Tree 1: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(0), normal: [1.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2]>, roots: [1], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -463,7 +503,6 @@ fn delete_one_leaf_in_a_split() {
     Item 2: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [2.0000, 0.0000] })
     Tree 0: Descendants(Descendants { descendants: [1, 2] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[1, 2]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -485,7 +524,6 @@ fn delete_one_item_in_a_single_document_database() {
     Item 0: Leaf(Leaf { header: NodeHeaderAngular { norm: 0.0 }, vector: [0.0000, 0.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0]>, roots: [0], distance: "angular" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -500,7 +538,6 @@ fn delete_one_item_in_a_single_document_database() {
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[]>, roots: [], distance: "angular" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -533,7 +570,6 @@ fn delete_one_item() {
     Tree 3: SplitPlaneNormal(SplitPlaneNormal { left: Tree(1), right: Tree(2), normal: [0.0000, 0.0000] })
     Tree 4: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(3), normal: [1.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 3, 4, 5]>, roots: [4], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -557,7 +593,6 @@ fn delete_one_item() {
     Tree 3: SplitPlaneNormal(SplitPlaneNormal { left: Tree(1), right: Tree(2), normal: [0.0000, 0.0000] })
     Tree 4: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(3), normal: [1.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 4, 5]>, roots: [4], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     // delete the last item in a descendants node
@@ -580,7 +615,6 @@ fn delete_one_item() {
     Tree 3: SplitPlaneNormal(SplitPlaneNormal { left: Item(2), right: Tree(2), normal: [0.0000, 0.0000] })
     Tree 4: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(3), normal: [1.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 2, 4, 5]>, roots: [4], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -597,7 +631,6 @@ fn add_one_item_incrementally_in_an_empty_db() {
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[]>, roots: [], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -612,7 +645,6 @@ fn add_one_item_incrementally_in_an_empty_db() {
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -632,7 +664,6 @@ fn add_one_item_incrementally_in_a_one_item_db() {
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
     Tree 0: Descendants(Descendants { descendants: [0] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -648,7 +679,6 @@ fn add_one_item_incrementally_in_a_one_item_db() {
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [1.0000, 0.0000] })
     Tree 0: Descendants(Descendants { descendants: [0, 1] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -670,7 +700,6 @@ fn add_one_item_incrementally_to_create_a_split_node() {
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [1.0000, 0.0000] })
     Tree 0: Descendants(Descendants { descendants: [0, 1] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1]>, roots: [0], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -688,7 +717,6 @@ fn add_one_item_incrementally_to_create_a_split_node() {
     Tree 1: Descendants(Descendants { descendants: [1, 2] })
     Tree 2: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(1), normal: [1.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2]>, roots: [2], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -720,7 +748,6 @@ fn add_one_item_incrementally() {
     Tree 3: SplitPlaneNormal(SplitPlaneNormal { left: Tree(1), right: Tree(2), normal: [0.0000, 0.0000] })
     Tree 4: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(3), normal: [1.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 3, 4, 5]>, roots: [4], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -748,7 +775,6 @@ fn add_one_item_incrementally() {
     Tree 4: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(3), normal: [1.0000, 0.0000] })
     Tree 5: Descendants(Descendants { descendants: [2, 25] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 3, 4, 5, 25]>, roots: [4], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -778,7 +804,6 @@ fn add_one_item_incrementally() {
     Tree 6: Descendants(Descendants { descendants: [8, 25] })
     Tree 7: SplitPlaneNormal(SplitPlaneNormal { left: Tree(6), right: Item(2), normal: [0.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 3, 4, 5, 8, 25]>, roots: [4], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -811,7 +836,6 @@ fn delete_extraneous_tree() {
     Tree 4: Descendants(Descendants { descendants: [1, 2, 3, 4] })
     Tree 5: SplitPlaneNormal(SplitPlaneNormal { left: Tree(4), right: Item(0), normal: [-1.0000, 0.0000, 0.0000, 0.0000] })
     Root: Metadata { dimensions: 4, items: RoaringBitmap<[0, 1, 2, 3, 4]>, roots: [1, 3, 5], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -832,7 +856,6 @@ fn delete_extraneous_tree() {
     Tree 4: Descendants(Descendants { descendants: [1, 2, 3, 4] })
     Tree 5: SplitPlaneNormal(SplitPlaneNormal { left: Tree(4), right: Item(0), normal: [-1.0000, 0.0000, 0.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 3, 4]>, roots: [3, 5], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -851,7 +874,6 @@ fn delete_extraneous_tree() {
     Tree 4: Descendants(Descendants { descendants: [1, 2, 3, 4] })
     Tree 5: SplitPlaneNormal(SplitPlaneNormal { left: Tree(4), right: Item(0), normal: [-1.0000, 0.0000, 0.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 3, 4]>, roots: [5], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }
 
@@ -883,7 +905,6 @@ fn reuse_node_id() {
     Tree 3: SplitPlaneNormal(SplitPlaneNormal { left: Tree(1), right: Tree(2), normal: [0.0000, 0.0000] })
     Tree 4: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(3), normal: [1.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 3, 4, 5]>, roots: [4], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -907,7 +928,6 @@ fn reuse_node_id() {
     Tree 3: SplitPlaneNormal(SplitPlaneNormal { left: Tree(1), right: Tree(2), normal: [0.0000, 0.0000] })
     Tree 4: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(3), normal: [1.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 2, 3, 4, 5]>, roots: [4], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -933,7 +953,6 @@ fn reuse_node_id() {
     Tree 4: SplitPlaneNormal(SplitPlaneNormal { left: Item(0), right: Tree(3), normal: [1.0000, 0.0000] })
     Tree 5: SplitPlaneNormal(SplitPlaneNormal { left: Tree(0), right: Item(1), normal: [0.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 3, 4, 5]>, roots: [4], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
@@ -963,6 +982,5 @@ fn reuse_node_id() {
     Tree 8: SplitPlaneNormal(SplitPlaneNormal { left: Tree(6), right: Tree(7), normal: [0.0000, 0.0000] })
     Tree 9: SplitPlaneNormal(SplitPlaneNormal { left: Tree(8), right: Item(0), normal: [-1.0000, 0.0000] })
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2, 3, 4, 5]>, roots: [4, 9], distance: "euclidean" }
-    updated_item_ids: RoaringBitmap<[]>
     "###);
 }

--- a/src/tests/writer.rs
+++ b/src/tests/writer.rs
@@ -95,7 +95,6 @@ fn write_one_vector() {
 
 #[test]
 fn write_one_vector_in_one_tree() {
-    let _ = env_logger::builder().is_test(true).parse_filters("trace").try_init();
     let handle = create_database::<Euclidean>();
     let mut wtxn = handle.env.write_txn().unwrap();
     let writer = Writer::new(handle.database, 0, 3);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -95,6 +95,20 @@ impl<D: Distance> Writer<D> {
         self.iter(rtxn).map(|mut iter| iter.next().is_none())
     }
 
+    /// Returns `true` if the index needs to be built before being able to read in it.
+    pub fn need_build(&self, rtxn: &RoTxn) -> Result<bool> {
+        Ok(self
+            .database
+            .remap_data_type::<DecodeIgnore>()
+            .get(rtxn, &Key::updated(self.index))?
+            .is_some()
+            || self
+                .database
+                .remap_data_type::<DecodeIgnore>()
+                .get(rtxn, &Key::metadata(self.index))?
+                .is_none())
+    }
+
     /// Returns `true` if the database contains the given item.
     pub fn contains_item(&self, rtxn: &RoTxn, item: ItemId) -> Result<bool> {
         self.database

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -775,7 +775,7 @@ impl<D: Distance> Writer<D> {
 
     fn delete_tree(&self, wtxn: &mut RwTxn, node: NodeId) -> Result<()> {
         let key = Key::new(self.index, node);
-        match self.database.get(wtxn, &key)?.ok_or(Error::MissingKey(key))? {
+        match self.database.get(wtxn, &key)?.ok_or(Error::missing_key(key))? {
             // the leafs are shared between the trees, we MUST NOT delete them.
             Node::Leaf(_) => Ok(()),
             Node::Descendants(_) => {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -775,7 +775,7 @@ impl<D: Distance> Writer<D> {
 
     fn delete_tree(&self, wtxn: &mut RwTxn, node: NodeId) -> Result<()> {
         let key = Key::new(self.index, node);
-        match self.database.get(wtxn, &key)?.ok_or(Error::MissingNode)? {
+        match self.database.get(wtxn, &key)?.ok_or(Error::MissingKey(key))? {
             // the leafs are shared between the trees, we MUST NOT delete them.
             Node::Leaf(_) => Ok(()),
             Node::Descendants(_) => {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -284,11 +284,7 @@ impl<D: Distance> Writer<D> {
             }
 
             log::debug!("reset the updated items...");
-            self.database.remap_data_type::<RoaringBitmapCodec>().put(
-                wtxn,
-                &Key::updated(self.index),
-                &RoaringBitmap::new(),
-            )?;
+            self.database.delete(wtxn, &Key::updated(self.index))?;
 
             log::debug!("write the metadata...");
             let metadata = Metadata {
@@ -400,11 +396,7 @@ impl<D: Distance> Writer<D> {
         }
 
         log::debug!("reset the updated items...");
-        self.database.remap_data_type::<RoaringBitmapCodec>().put(
-            wtxn,
-            &Key::updated(self.index),
-            &RoaringBitmap::new(),
-        )?;
+        self.database.delete(wtxn, &Key::updated(self.index))?;
 
         log::debug!("write the metadata...");
         let metadata = Metadata {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #74 

## What does this PR do?
- Ensure the database has been fully built before attempting any search request (=> there are no items to update)
- Delete the `updated` item list instead of emptying it
- Provide a new method on the `Writer` to know if we need to build the tree or can simply drop the writer
- Add a new test
- Return an error message instead of panicking when a key is missing
