### PR TITLE
Cancellation Support

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 use std::io;
 
-use crate::{key::Key, node_id::NodeMode, ItemId};
+use crate::key::Key;
+use crate::node_id::NodeMode;
+use crate::ItemId;
 
 /// The different set of errors that arroy can encounter.
 #[derive(Debug, thiserror::Error)]
@@ -61,6 +63,9 @@ pub enum Error {
         /// The item ID queried
         item: ItemId,
     },
+
+    #[error("The corresponding build process has been cancelled")]
+    BuildCancelled,
 }
 
 impl Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ use node::{Node, NodeCodec};
 use node_id::{NodeId, NodeMode};
 pub use reader::Reader;
 pub use stats::{Stats, TreeStats};
-pub use writer::Writer;
+pub use writer::{TreeBuildCanceller, Writer};
 
 /// The set of types used by the [`Distance`] trait.
 pub mod internals {


### PR DESCRIPTION
This PR fixes #85 by implementing a cancellation system. It exposes a new method that provides a structure for canceling the current build operation.

This PR is breaking as it exposes a new error type: `BuildCancelled`.