### PR TITLE
use the bias as intended

### DIFF
--- a/src/distance/angular.rs
+++ b/src/distance/angular.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use bytemuck::{Pod, Zeroable};
 use rand::Rng;
 
@@ -67,7 +65,7 @@ impl Distance for Angular {
     fn create_split<'a, R: Rng>(
         children: &'a ImmutableSubsetLeafs<Self>,
         rng: &mut R,
-    ) -> heed::Result<Cow<'a, UnalignedVector<Self::VectorCodec>>> {
+    ) -> heed::Result<Leaf<'static, Self>> {
         let [node_p, node_q] = two_means(rng, children, true)?;
         let vector: Vec<f32> =
             node_p.vector.iter().zip(node_q.vector.iter()).map(|(p, q)| p - q).collect();
@@ -75,7 +73,7 @@ impl Distance for Angular {
         let mut normal = Leaf { header: NodeHeaderAngular { norm: 0.0 }, vector: unaligned_vector };
         Self::normalize(&mut normal);
 
-        Ok(normal.vector)
+        Ok(normal)
     }
 
     fn margin_no_header(

--- a/src/distance/binary_quantized_angular.rs
+++ b/src/distance/binary_quantized_angular.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use bytemuck::{Pod, Zeroable};
 use rand::Rng;
 
@@ -72,7 +70,7 @@ impl Distance for BinaryQuantizedAngular {
     fn create_split<'a, R: Rng>(
         children: &'a ImmutableSubsetLeafs<Self>,
         rng: &mut R,
-    ) -> heed::Result<Cow<'a, UnalignedVector<Self::VectorCodec>>> {
+    ) -> heed::Result<Leaf<'static, Self>> {
         let [node_p, node_q] = two_means::<Self, Angular, R>(rng, children, true)?;
         let vector: Vec<f32> =
             node_p.vector.iter().zip(node_q.vector.iter()).map(|(p, q)| p - q).collect();
@@ -83,7 +81,7 @@ impl Distance for BinaryQuantizedAngular {
         };
         Self::normalize(&mut normal);
 
-        Ok(normal.vector)
+        Ok(normal)
     }
 
     fn margin_no_header(

--- a/src/distance/binary_quantized_manhattan.rs
+++ b/src/distance/binary_quantized_manhattan.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use bytemuck::{Pod, Zeroable};
 use rand::Rng;
 
-use super::{two_means_binary_quantized as two_means, Manhattan};
+use super::{two_means_binary_quantized as two_means, Manhattan, NodeHeaderManhattan};
 use crate::distance::Distance;
 use crate::node::Leaf;
 use crate::parallel::ImmutableSubsetLeafs;
@@ -63,17 +63,35 @@ impl Distance for BinaryQuantizedManhattan {
     fn create_split<'a, R: Rng>(
         children: &'a ImmutableSubsetLeafs<Self>,
         rng: &mut R,
-    ) -> heed::Result<Cow<'a, UnalignedVector<Self::VectorCodec>>> {
+    ) -> heed::Result<Leaf<'static, Self>> {
         let [node_p, node_q] = two_means::<Self, Manhattan, R>(rng, children, false)?;
         let vector: Vec<f32> =
             node_p.vector.iter().zip(node_q.vector.iter()).map(|(p, q)| p - q).collect();
         let mut normal = Leaf {
-            header: NodeHeaderBinaryQuantizedManhattan { bias: 0.0 },
+            header: NodeHeaderBinaryQuantizedManhattan::zeroed(),
             vector: UnalignedVector::from_slice(&vector),
         };
         Self::normalize(&mut normal);
 
-        Ok(Cow::Owned(normal.vector.into_owned()))
+        normal.header.bias = normal
+            .vector
+            .iter()
+            .zip(
+                UnalignedVector::<BinaryQuantized>::from_slice(
+                    &node_p.vector.iter().collect::<Vec<_>>(),
+                )
+                .iter(),
+            )
+            .zip(
+                UnalignedVector::<BinaryQuantized>::from_slice(
+                    &node_q.vector.iter().collect::<Vec<_>>(),
+                )
+                .iter(),
+            )
+            .map(|((n, p), q)| -n * (p + q) / 2.0)
+            .sum();
+
+        Ok(normal.into_owned())
     }
 
     fn margin(p: &Leaf<Self>, q: &Leaf<Self>) -> f32 {

--- a/src/distance/dot_product.rs
+++ b/src/distance/dot_product.rs
@@ -90,7 +90,7 @@ impl Distance for DotProduct {
     fn create_split<'a, R: Rng>(
         children: &'a ImmutableSubsetLeafs<Self>,
         rng: &mut R,
-    ) -> heed::Result<Cow<'a, UnalignedVector<Self::VectorCodec>>> {
+    ) -> heed::Result<Leaf<'static, Self>> {
         let [node_p, node_q] = two_means(rng, children, true)?;
         let vector: Vec<f32> =
             node_p.vector.iter().zip(node_q.vector.iter()).map(|(p, q)| p - q).collect();
@@ -101,7 +101,7 @@ impl Distance for DotProduct {
         normal.header.extra_dim = node_p.header.extra_dim - node_q.header.extra_dim;
         Self::normalize(&mut normal);
 
-        Ok(normal.vector)
+        Ok(normal)
     }
 
     fn margin(p: &Leaf<Self>, q: &Leaf<Self>) -> f32 {

--- a/src/distance/euclidean.rs
+++ b/src/distance/euclidean.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use bytemuck::{Pod, Zeroable};
 use rand::Rng;
 
@@ -50,7 +48,7 @@ impl Distance for Euclidean {
     fn create_split<'a, R: Rng>(
         children: &'a ImmutableSubsetLeafs<Self>,
         rng: &mut R,
-    ) -> heed::Result<Cow<'a, UnalignedVector<Self::VectorCodec>>> {
+    ) -> heed::Result<Leaf<'static, Self>> {
         let [node_p, node_q] = two_means(rng, children, false)?;
         let vector: Vec<_> =
             node_p.vector.iter().zip(node_q.vector.iter()).map(|(p, q)| p - q).collect();
@@ -68,7 +66,7 @@ impl Distance for Euclidean {
             .map(|((n, p), q)| -n * (p + q) / 2.0)
             .sum();
 
-        Ok(normal.vector)
+        Ok(normal)
     }
 
     fn margin(p: &Leaf<Self>, q: &Leaf<Self>) -> f32 {

--- a/src/distance/manhattan.rs
+++ b/src/distance/manhattan.rs
@@ -53,7 +53,7 @@ impl Distance for Manhattan {
     fn create_split<'a, R: Rng>(
         children: &'a ImmutableSubsetLeafs<Self>,
         rng: &mut R,
-    ) -> heed::Result<Cow<'a, UnalignedVector<Self::VectorCodec>>> {
+    ) -> heed::Result<Leaf<'static, Self>> {
         let [node_p, node_q] = two_means(rng, children, false)?;
         let vector: Vec<_> =
             node_p.vector.iter().zip(node_q.vector.iter()).map(|(p, q)| p - q).collect();
@@ -71,7 +71,7 @@ impl Distance for Manhattan {
             .map(|((n, p), q)| -n * (p + q) / 2.0)
             .sum();
 
-        Ok(normal.vector)
+        Ok(normal)
     }
 
     fn margin(p: &Leaf<Self>, q: &Leaf<Self>) -> f32 {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -102,7 +102,7 @@ impl<'t, D: Distance> Reader<'t, D> {
                 Node::SplitPlaneNormal(SplitPlaneNormal { normal, left, right }) => {
                     let left = recursive_depth(rtxn, database, index, left)?;
                     let right = recursive_depth(rtxn, database, index, right)?;
-                    let is_zero_normal = normal.is_zero() as usize;
+                    let is_zero_normal = normal.vector.is_zero() as usize;
 
                     Ok(TreeStats {
                         depth: 1 + left.depth.max(right.depth),
@@ -258,7 +258,7 @@ impl<'t, D: Distance> Reader<'t, D> {
                     }
                 }
                 Node::SplitPlaneNormal(SplitPlaneNormal { normal, left, right }) => {
-                    let margin = D::margin_no_header(&normal, &query_leaf.vector);
+                    let margin = D::margin(&normal, &query_leaf);
                     queue.push((OrderedFloat(D::pq_distance(dist, margin, Side::Left)), left));
                     queue.push((OrderedFloat(D::pq_distance(dist, margin, Side::Right)), right));
                 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -10,7 +10,7 @@ use rayon::iter::repeatn;
 use rayon::prelude::*;
 use roaring::RoaringBitmap;
 
-use crate::distance::Distance;
+use crate::distance::{new_leaf, Distance};
 use crate::internals::{KeyCodec, Side};
 use crate::item_iter::ItemIter;
 use crate::node::{Descendants, ItemIds, Leaf, SplitPlaneNormal};
@@ -563,7 +563,7 @@ impl<D: Distance> Writer<D> {
                         let mut left_ids = RoaringBitmap::new();
                         let mut right_ids = RoaringBitmap::new();
 
-                        if normal.is_zero() {
+                        if normal.vector.is_zero() {
                             randomly_split_children(rng, to_insert, &mut left_ids, &mut right_ids);
                         } else {
                             for leaf in to_insert {
@@ -730,7 +730,7 @@ impl<D: Distance> Writer<D> {
                 let mut children_left = RoaringBitmap::new();
                 let mut children_right = RoaringBitmap::new();
                 randomly_split_children(rng, item_indices, &mut children_left, &mut children_right);
-                UnalignedVector::reset(&mut normal);
+                UnalignedVector::reset(&mut normal.vector);
 
                 (children_left, children_right)
             } else {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/arroy/issues/81

## What does this PR do?
- After looking into annoy it looks like we ignored the bias for the euclidean and manhattan distance, but using the bias the recall improved a little bit on small dimension datasets:
On main:
![image](https://github.com/user-attachments/assets/5cc0939d-e9a6-4d7b-8932-49e74ed7efb7)
After this PR:
![image](https://github.com/user-attachments/assets/6e210d51-8e9c-4ed8-9336-6b71004758fd)

> ![WARNING]
> Currently, this doesn't apply to the angular distance, we need to read the annoy code further to understand what they’re doing with the norm and if we’re doing everything correctly


### And for the binary quantization?

Currently, I don't really know how we should implements that for the binary quantization. I did a few tests here and some improved the recall sometimes for almost 10 points:
![image](https://github.com/user-attachments/assets/739ebf1c-5c95-4844-9bf9-f2771ee184e9)
