### PR TITLE
Make the warning output errors in the ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: ['main']
 
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: "-D warnings"
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/src/unaligned_vector/f32.rs
+++ b/src/unaligned_vector/f32.rs
@@ -14,7 +14,7 @@ impl UnalignedVectorCodec for f32 {
         let rem = bytes.len() % size_of::<f32>();
         if rem == 0 {
             // safety: `UnalignedF32Slice` is transparent
-            Ok(Cow::Borrowed(unsafe { transmute(bytes) }))
+            Ok(Cow::Borrowed(unsafe { transmute::<&[u8], &UnalignedVector<f32>>(bytes) }))
         } else {
             Err(SizeMismatch { vector_codec: "f32", rem })
         }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
To avoid letting this kind of stuff get merged and then having github pollute all the code review
<img width="1542" alt="image" src="https://github.com/user-attachments/assets/e1d0903f-5da2-4b7f-8d52-03f6ba416f8a">

It’s better to treat all warning as an error
