### PR TITLE
Store the list of updated IDs directly in LMDB instead of a roaring bitmap

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -75,7 +75,7 @@ impl Error {
                 NodeMode::Item => "Item",
                 NodeMode::Tree => "Tree",
                 NodeMode::Metadata => "Metadata",
-                NodeMode::Updated => todo!(),
+                NodeMode::Updated => "Updated",
             },
             item: key.node.item,
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,7 @@ impl Error {
                 NodeMode::Item => "Item",
                 NodeMode::Tree => "Tree",
                 NodeMode::Metadata => "Metadata",
+                NodeMode::Updated => todo!(),
             },
             item: key.node.item,
         }

--- a/src/key.rs
+++ b/src/key.rs
@@ -7,12 +7,13 @@ use heed::BoxedError;
 use crate::{NodeId, NodeMode};
 
 /// This whole structure must fit in an u64 so we can tell LMDB to optimize its storage.
-/// The `prefix` is specified by the user and is used to differentiate between multiple arroy indexes.
+/// The `index` is specified by the user and is used to differentiate between multiple arroy indexes.
 /// The `mode` indicates what we're looking at.
 /// The `item` point to a specific node.
 /// If the mode is:
 ///  - `Item`: we're looking at a `Leaf` node.
 ///  - `Tree`: we're looking at one of the internal generated node from arroy. Could be a descendants or a split plane.
+///  - `Updated`: The list of items that has been updated since the last build of the database.
 ///  - `Metadata`: There is only one item at `0` that contains the header required to read the index.
 #[derive(Debug, Copy, Clone)]
 pub struct Key {
@@ -32,8 +33,8 @@ impl Key {
         Self::new(index, NodeId::metadata())
     }
 
-    pub const fn updated(index: u16) -> Self {
-        Self::new(index, NodeId::updated())
+    pub const fn updated(index: u16, item: u32) -> Self {
+        Self::new(index, NodeId::updated(item))
     }
 
     pub const fn item(index: u16, item: u32) -> Self {
@@ -97,6 +98,10 @@ impl Prefix {
 
     pub const fn tree(index: u16) -> Self {
         Self { index, mode: Some(NodeMode::Tree) }
+    }
+
+    pub const fn updated(index: u16) -> Self {
+        Self { index, mode: Some(NodeMode::Updated) }
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4,7 +4,7 @@ use std::iter::repeat;
 use std::marker;
 use std::num::NonZeroUsize;
 
-use heed::types::{Bytes, DecodeIgnore};
+use heed::types::DecodeIgnore;
 use heed::RoTxn;
 use ordered_float::OrderedFloat;
 use roaring::RoaringBitmap;
@@ -146,7 +146,13 @@ impl<'t, D: Distance> Reader<'t, D> {
                 received: D::name(),
             });
         }
-        if database.remap_data_type::<Bytes>().get(rtxn, &Key::updated(index))?.is_some() {
+        if database
+            .remap_types::<PrefixCodec, DecodeIgnore>()
+            .prefix_iter(rtxn, &Prefix::updated(index))?
+            .remap_key_type::<KeyCodec>()
+            .next()
+            .is_some()
+        {
             return Err(Error::NeedBuild(index));
         }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -77,10 +77,7 @@ impl<D: Distance> fmt::Display for DatabaseHandle<D> {
                         .unwrap();
                     writeln!(f, "updated_item_ids: {updated_item_ids:?}")?;
                 }
-                NodeMode::Metadata => {
-                    panic!()
-                }
-                NodeMode::Updated => todo!(),
+                NodeMode::Updated | NodeMode::Metadata => panic!(),
             }
         }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -80,6 +80,7 @@ impl<D: Distance> fmt::Display for DatabaseHandle<D> {
                 NodeMode::Metadata => {
                     panic!()
                 }
+                NodeMode::Updated => todo!(),
             }
         }
 


### PR DESCRIPTION
# Pull Request

After chatting with @ManyTheFish, we realized that deserializing a roaring bitmap, inserting an item, and serializing it again into LMDB every time we insert a new item wasn’t the smartest idea.
Ideally, we should write each document in a simple file or in RAM, but that adds a lot of complexity to the usage of arroy.
By simply writing the updated item ID directly in a database we were able to add 1M items in 1.7s instead of 18s+.

The drawback is that we use slightly more memory, but as a reminder, adding 150M vectors in one batch would only use around 0.5GiB (plus the LMDB internal structures).
This is clearly acceptable considering it’s memory mapped, and storing the vectors is going to take **at least** around 300GiB.

## What does this PR do?
- Create a new kind of node ID `updated` where every associated `ItemId` represents the item ID of something we updated
- Update the rest of the code accordingly
- The tests still works 👌 
