### PR TITLE
Numerical stability improvements for Cosine Distance

### DIFF
--- a/src/distance/cosine.rs
+++ b/src/distance/cosine.rs
@@ -40,8 +40,9 @@ impl Distance for Cosine {
         let qn = q.header.norm;
         let pq = dot_product(&p.vector, &q.vector);
         let pnqn = pn * qn;
-        if pnqn != 0.0 {
+        if pnqn > f32::EPSILON {
             let cos = pq / pnqn;
+            let cos = cos.clamp(-1.0, 1.0);
             // cos is [-1; 1]
             // cos =  0. -> 0.5
             // cos = -1. -> 1.0


### PR DESCRIPTION
# Pull Request

## Changes
- Added `f32::EPSILON` threshold check instead of strict zero comparison
- Added `clamp()` to ensure cosine stays within [-1, 1] range

## Technical Details
The main improvement addresses potential floating-point precision issues:
- Previously, the code used `pnqn != 0.0` which can be unreliable with floating-point arithmetic
- Now uses `pnqn > f32::EPSILON` to properly handle near-zero magnitudes
- Added protection against rounding errors that could push cosine outside [-1, 1]

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


