### PR TITLE
Reduce ram consumption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ roaring = "0.10.9"
 tempfile = "3.15.0"
 thiserror = "2.0.9"
 nohash = "0.2.0"
+page_size = "0.6.0"
 
 [dev-dependencies]
 anyhow = "1.0.95"

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -9,8 +9,7 @@ use heed::types::Bytes;
 use heed::{BytesDecode, BytesEncode, RoTxn};
 use memmap2::Mmap;
 use nohash::{BuildNoHashHasher, IntMap};
-use ordered_float::{Float, FloatCore};
-use rand::seq::{index, IteratorRandom};
+use rand::seq::index;
 use rand::Rng;
 use roaring::{RoaringBitmap, RoaringTreemap};
 

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -295,14 +295,10 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
 
             // We count how many pages would be added to the treemap to see if we're going
             // to exceed the allowed number of pages
-            let mut new_pages_selected = 0;
-            for p in pages {
-                if !pages_selected.contains(*p as u64) {
-                    new_pages_selected += 1;
-                }
-            }
+            let new_pages_selected =
+                pages.iter().filter(|p| !pages_selected.contains(**p as u64)).count();
 
-            if (pages_selected.len() + new_pages_selected) > pages_fit_in_ram as u64
+            if (pages_selected.len() + new_pages_selected as u64) > pages_fit_in_ram as u64
                 && vector_selected.len() >= 200
             {
                 break;

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -243,7 +243,7 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
                 .constant_length
                 .expect("Constant length is missing even though there are vectors");
             let vectors_fits_in_memory = memory / leaf_size;
-            let vectors_fits_in_memory = vectors_fits_in_memory.min(self.leafs.len());
+            let vectors_fits_in_memory = vectors_fits_in_memory.min(self.leafs.len()).max(200);
             println!("{vectors_fits_in_memory} vectors fits in memory");
             let items = self.leafs.keys().choose_multiple(rng, vectors_fits_in_memory);
             RoaringBitmap::from_iter(items)

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -273,7 +273,7 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
                 let current_page_number = current / page_size;
                 let page_to_items_entry =
                     pages_to_items.entry(current_page_number).or_insert_with(|| {
-                        Vec::with_capacity((theorical_vectors_per_page.ceil() as usize + 1))
+                        Vec::with_capacity(theorical_vectors_per_page.ceil() as usize + 1)
                     });
                 debug_assert!(!page_to_items_entry.contains(item));
                 page_to_items_entry.push(*item);
@@ -296,12 +296,13 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
             // We count how many pages would be added to the treemap to see if we're going
             // to exceed the allowed number of pages
             let mut new_pages_selected = 0;
-            for p in pages.iter() {
-                if !pages_selected.contains(p) {
+            for p in pages {
+                if !pages_selected.contains(*p as u64) {
                     new_pages_selected += 1;
                 }
             }
-            if (pages_selected_after_insertion + new_pages_selected) > pages_fit_in_ram as u64
+
+            if (pages_selected.len() + new_pages_selected) > pages_fit_in_ram as u64
                 && vector_selected.len() >= 200
             {
                 break;

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -251,6 +251,9 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
             let pages_fit_in_ram = memory / page_size;
             let theorical_nb_pages = self.leafs.len() as f64 / theorical_vectors_per_page;
 
+            // First step is to map both:
+            // - the page ptr with the items they contain
+            // - the items with the pages they're contained in
             let mut pages_to_items = IntMap::with_capacity_and_hasher(
                 theorical_nb_pages.ceil() as usize,
                 BuildNoHashHasher::default(),
@@ -263,10 +266,8 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
 
                 let mut current = a;
                 let end = a + leaf_size;
-                // TODO: use a smallVec
                 let mut pages = Vec::new();
                 while current < end {
-                    // TODO: use a smallVec
                     let page_to_items_entry =
                         pages_to_items.entry(current / page_size).or_insert(Vec::new());
                     if page_to_items_entry.last() != Some(item) {

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -234,7 +234,7 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
 
     /// Returns a set of items ID that fits in memory.
     /// The memory is specified in bytes and the sample size returned will contains at least 200 elements.
-    /// If there is less than 200 elements in the database then this number will be returned.
+    /// If there is less than 200 elements in the database then this number of elements will be returned.
     pub fn sample<R: Rng>(&self, memory: usize, rng: &mut R) -> RoaringBitmap {
         let page_size = page_size::get();
         let leaf_size =

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -273,7 +273,7 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
                 let current_page_number = current / page_size;
                 let page_to_items_entry = pages_to_items
                     .entry(current_page_number)
-                    .or_insert_with(|| Vec::with_capacity((*item) as usize));
+                    .or_insert_with(|| Vec::with_capacity((theorical_vectors_per_page.ceil() as usize + 1));
                 debug_assert!(!page_to_items_entry.contains(item));
                 page_to_items_entry.push(*item);
                 pages.push(current_page_number);
@@ -292,9 +292,15 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
             let item_id = candidates.select(rank).unwrap();
             let pages = items_to_pages.get(&item_id).unwrap();
 
-            let pages_selected_after_insertion = pages_selected
-                .union_len(&RoaringTreemap::from_iter(pages.iter().map(|a| *a as u64)));
-            if pages_selected_after_insertion > pages_fit_in_ram as u64
+            // We count how many pages would be added to the treemap to see if we're going
+            // to exceed the allowed number of pages 
+            let mut new_pages_selected = 0;
+            for p in pages.iter() {
+                if !pages_selected.contains(p) {
+                    new_pages_selected += 1;
+                }
+            }
+            if (pages_selected_after_insertion + new_pages_selected) > pages_fit_in_ram as u64
                 && vector_selected.len() >= 200
             {
                 break;

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -271,9 +271,10 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
             let mut pages = Vec::with_capacity(theorical_pages_per_vector.ceil() as usize + 1);
             while current < end {
                 let current_page_number = current / page_size;
-                let page_to_items_entry = pages_to_items
-                    .entry(current_page_number)
-                    .or_insert_with(|| Vec::with_capacity((theorical_vectors_per_page.ceil() as usize + 1));
+                let page_to_items_entry =
+                    pages_to_items.entry(current_page_number).or_insert_with(|| {
+                        Vec::with_capacity((theorical_vectors_per_page.ceil() as usize + 1))
+                    });
                 debug_assert!(!page_to_items_entry.contains(item));
                 page_to_items_entry.push(*item);
                 pages.push(current_page_number);
@@ -293,7 +294,7 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
             let pages = items_to_pages.get(&item_id).unwrap();
 
             // We count how many pages would be added to the treemap to see if we're going
-            // to exceed the allowed number of pages 
+            // to exceed the allowed number of pages
             let mut new_pages_selected = 0;
             for p in pages.iter() {
                 if !pages_selected.contains(p) {

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -243,6 +243,7 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
                 .constant_length
                 .expect("Constant length is missing even though there are vectors");
             let vectors_fits_in_memory = memory / leaf_size;
+            println!("{vectors_fits_in_memory} vectors fits in memory");
             let items = self
                 .leafs
                 .keys()

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -243,11 +243,9 @@ impl<'t, D: Distance> ImmutableLeafs<'t, D> {
                 .constant_length
                 .expect("Constant length is missing even though there are vectors");
             let vectors_fits_in_memory = memory / leaf_size;
+            let vectors_fits_in_memory = vectors_fits_in_memory.min(self.leafs.len());
             println!("{vectors_fits_in_memory} vectors fits in memory");
-            let items = self
-                .leafs
-                .keys()
-                .choose_multiple(rng, vectors_fits_in_memory.min(self.leafs.len()));
+            let items = self.leafs.keys().choose_multiple(rng, vectors_fits_in_memory);
             RoaringBitmap::from_iter(items)
         }
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -512,6 +512,7 @@ impl<D: Distance> Writer<D> {
         let used_node_ids = self.used_tree_node(wtxn)?;
         let nb_tree_nodes = used_node_ids.len();
 
+        println!("retrieving the frozen reader");
         let concurrent_node_ids = ConcurrentNodeIds::new(used_node_ids);
         let frozzen_reader = FrozzenReader {
             leafs: &ImmutableLeafs::new(wtxn, self.database, self.index, item_indices.len())?,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -908,6 +908,14 @@ impl<D: Distance> Writer<D> {
             return Ok(NodeId::tree(item_id));
         }
 
+        let intersection_len = two_means_candidates.intersection_len(item_indices);
+        let two_means_candidates = if intersection_len >= 2 {
+            two_means_candidates & item_indices
+        } else {
+            two_means_candidates.clone()
+        };
+        let two_means_candidates = &two_means_candidates;
+
         let children = ImmutableSubsetLeafs::from_item_ids(reader.leafs, two_means_candidates);
         let mut children_left = Vec::with_capacity(children.len() as usize);
         let mut children_right = Vec::with_capacity(children.len() as usize);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -620,6 +620,7 @@ impl<D: Distance> Writer<D> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn update_trees<R: Rng + SeedableRng>(
         &self,
         opt: &BuildOption,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -919,7 +919,7 @@ impl<D: Distance> Writer<D> {
 
             let normal = D::create_split(&children, rng)?;
             for item_id in item_indices.iter() {
-                let node = children.get(item_id)?.unwrap();
+                let node = reader.leafs.get(item_id)?.unwrap();
                 match D::side(&normal, &node, rng) {
                     Side::Left => children_left.push(item_id),
                     Side::Right => children_right.push(item_id),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -512,7 +512,6 @@ impl<D: Distance> Writer<D> {
         let used_node_ids = self.used_tree_node(wtxn)?;
         let nb_tree_nodes = used_node_ids.len();
 
-        println!("retrieving the frozen reader");
         let concurrent_node_ids = ConcurrentNodeIds::new(used_node_ids);
         let frozzen_reader = FrozzenReader {
             leafs: &ImmutableLeafs::new(wtxn, self.database, self.index, item_indices.len())?,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -98,6 +98,9 @@ impl<'a, D: Distance, R: Rng + SeedableRng> ArroyBuilder<'a, D, R> {
     /// If not specified, arroy will use as much memory as possible but keep in mind that if arroy tries to use more
     /// memory than you have, it'll become very slow.
     ///
+    /// In this case, it will randomly read the disk as pages will be invalidated by other reads, and OS cache will
+    /// become useless.
+    ///
     /// # Example
     ///
     /// ```no_run

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -92,7 +92,7 @@ impl<'a, D: Distance, R: Rng + SeedableRng> ArroyBuilder<'a, D, R> {
         self
     }
 
-    /// Configure the maximum memory arroy can use to build its tree in bytes.
+    /// Configure the maximum memory arroy can use to build its trees in bytes.
     ///
     /// This value is used as a hint; arroy may still consume too much memory, especially if the value is too low.
     /// If not specified, arroy will use as much memory as possible but keep in mind that if arroy tries to use more

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -911,13 +911,14 @@ impl<D: Distance> Writer<D> {
             return Ok(NodeId::tree(item_id));
         }
 
+        // If we don't have at least two vectors in common between the item_indices and the two_means_candidates
+        // we're going to use the whole list of two_means_candidates to create the split node.
         let intersection_len = two_means_candidates.intersection_len(item_indices);
         let two_means_candidates = if intersection_len >= 2 {
-            two_means_candidates & item_indices
+            &(two_means_candidates & item_indices)
         } else {
-            two_means_candidates.clone()
+            two_means_candidates
         };
-        let two_means_candidates = &two_means_candidates;
 
         let children = ImmutableSubsetLeafs::from_item_ids(reader.leafs, two_means_candidates);
         let mut children_left = Vec::with_capacity(children.len() as usize);


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/arroy/issues/87

## What does this PR do?
- Implements the last strategy described in #87
- Expose a new `memory` parameter in the `Writer::Builder` that specifies how much memory mapped memory arroy can use. It doesn't limit the RAM used by arroy itself, so this amount should always be smaller than your total RAM
