### PR TITLE
Bump heed to 0.22

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # RUSTFLAGS: "-D warnings"
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   test:
@@ -23,23 +23,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-
+      - uses: dtolnay/rust-toolchain@1.81
       - uses: actions-rs/cargo@v1
         with:
           command: build
           args: --all-targets ${{ matrix.features }}
-
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
-
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -48,19 +40,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@1.81
         with:
           profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
+          components: clippy, rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-
       - uses: actions-rs/cargo@v1
         if: always()
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,14 +2,14 @@ name: Rust CI
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
   pull_request:
-    branches: ['main']
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  RUSTFLAGS: "-D warnings"
+  # RUSTFLAGS: "-D warnings"
 
 jobs:
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 [dependencies]
 bytemuck = { version = "1.21.0", features = ["derive", "extern_crate_alloc"] }
 byteorder = "1.5.0"
-heed = { branch = "bump-versions", git = "https://github.com/meilisearch/heed", default-features = false }
+heed = { branch = "main", git = "https://github.com/meilisearch/heed", default-features = false }
 log = "0.4.22"
 memmap2 = "0.9.5"
 ordered-float = "4.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,17 @@ documentation = "https://docs.rs/arroy"
 repository = "https://github.com/meilisearch/arroy"
 keywords = ["ANN-search", "Graph-algorithms", "Vector-Search", "Store"]
 categories = ["algorithms", "database", "data-structures", "science"]
-authors = ["Kerollmops <clement@meilisearch.com>", "Tamo <tamo@meilisearch.com>"]
+authors = [
+    "Kerollmops <clement@meilisearch.com>",
+    "Tamo <tamo@meilisearch.com>",
+]
 license = "MIT"
 edition = "2021"
 
 [dependencies]
 bytemuck = { version = "1.21.0", features = ["derive", "extern_crate_alloc"] }
 byteorder = "1.5.0"
-heed = { version = "0.21.0", default-features = false }
+heed = { branch = "bump-versions", git = "https://github.com/meilisearch/heed", default-features = false }
 log = "0.4.22"
 memmap2 = "0.9.5"
 ordered-float = "4.6.0"

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use heed::types::LazyDecode;
-use heed::{Env, EnvOpenOptions};
+use heed::{Env, EnvOpenOptions, WithTls};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use tempfile::TempDir;
@@ -14,7 +14,7 @@ mod reader;
 mod writer;
 
 pub struct DatabaseHandle<D> {
-    pub env: Env,
+    pub env: Env<WithTls>,
     pub database: Database<D>,
     #[allow(unused)]
     pub tempdir: TempDir,


### PR DESCRIPTION
This PR bumps heed to the 0.22 unreleased version. As it is breaking, we must also bump the arroy's version.