### PR TITLE
Implement Hamming distance for binary strings

### DIFF
--- a/proptest-regressions/unaligned_vector/binary_test.txt
+++ b/proptest-regressions/unaligned_vector/binary_test.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4044d46b46fbadeb98b1c37a1b7ec57f00fe21008401479d30f2f39aa83e3195 # shrinks to original = [0.0]

--- a/src/distance/hamming.rs
+++ b/src/distance/hamming.rs
@@ -1,0 +1,143 @@
+use crate::distance::Distance;
+use crate::node::Leaf;
+use crate::parallel::ImmutableSubsetLeafs;
+use crate::unaligned_vector::{Binary, UnalignedVector};
+use bytemuck::{Pod, Zeroable};
+use rand::Rng;
+use std::borrow::Cow;
+
+/// The Hamming distance between two vectors is the number of positions at
+/// which the corresponding symbols are different.
+///
+/// `d(u,v) = ||u ^ v||₁`
+///
+/// /!\ This distance function is binary, which means it loses all its precision
+///     and their scalar values are converted to `0` or `1` under the rule
+///     `x > 0.0 => 1`, otherwise `0`
+#[derive(Debug, Clone)]
+pub enum Hamming {}
+
+/// The header of BinaryEuclidean leaf nodes.
+#[repr(C)]
+#[derive(Pod, Zeroable, Debug, Clone, Copy)]
+pub struct NodeHeaderHamming {}
+
+impl Distance for Hamming {
+    const DEFAULT_OVERSAMPLING: usize = 3;
+
+    type Header = NodeHeaderHamming;
+    type VectorCodec = Binary;
+
+    fn name() -> &'static str {
+        "hamming"
+    }
+
+    fn new_header(_vector: &UnalignedVector<Self::VectorCodec>) -> Self::Header {
+        NodeHeaderHamming {}
+    }
+
+    fn built_distance(p: &Leaf<Self>, q: &Leaf<Self>) -> f32 {
+        hamming_bitwise_fast(p.vector.as_bytes(), q.vector.as_bytes())
+    }
+
+    fn normalized_distance(d: f32, dimensions: usize) -> f32 {
+        d.max(0.0) / dimensions as f32
+    }
+
+    fn norm_no_header(v: &UnalignedVector<Self::VectorCodec>) -> f32 {
+        v.as_bytes().iter().map(|b| b.count_ones() as i32).sum::<i32>() as f32
+    }
+
+    fn init(_node: &mut Leaf<Self>) {}
+
+    fn create_split<'a, R: Rng>(
+        children: &'a ImmutableSubsetLeafs<Self>,
+        rng: &mut R,
+    ) -> heed::Result<Cow<'a, UnalignedVector<Self::VectorCodec>>> {
+        // unlike other distances which build a seperating hyperplane we
+        // construct an LSH by bit sampling and store the random bit in a one-hot 
+        // vector
+        // https://en.wikipedia.org/wiki/Locality-sensitive_hashing#Bit_sampling_for_Hamming_distance
+
+        const ITERATION_STEPS: usize = 200;
+
+        let is_valid_split = |v: &UnalignedVector<Self::VectorCodec>, rng: &mut R| {
+            let mut count = 0;
+            for _ in 0..ITERATION_STEPS {
+                let u = children.choose(rng)?.unwrap().vector;
+                if <Self as Distance>::margin_no_header(v, u.as_ref()) > 0.0 {
+                    count += 1;
+                }
+            }
+            Ok::<bool, heed::Error>(count > 0 && count < ITERATION_STEPS)
+        };
+
+        // first try random index
+        let dim = children.choose(rng)?.unwrap().vector.len();
+        let mut n: Vec<f32> = vec![0.0; dim];
+        let idx = rng.gen_range(0..dim);
+        n[idx] = 1.0;
+        let mut normal = UnalignedVector::from_vec(n);
+
+        if is_valid_split(&normal, rng)? {
+            return Ok(Cow::Owned(normal.into_owned()));
+        }
+
+        // otherwise brute-force search for a splitting coordinate
+        for j in 0..dim {
+            let mut n: Vec<f32> = vec![0.0; dim];
+            n[j] = 1.0;
+            normal = UnalignedVector::from_vec(n);
+
+            if is_valid_split(&normal, rng)? {
+                return Ok(Cow::Owned(normal.into_owned()));
+            }
+        }
+
+        // fallback
+        Ok(Cow::Owned(normal.into_owned()))
+    }
+
+    fn margin_no_header(
+        p: &UnalignedVector<Self::VectorCodec>,
+        q: &UnalignedVector<Self::VectorCodec>,
+    ) -> f32 {
+        // p is a mask with 1 bit set
+        let ret =
+            p.as_bytes().iter().zip(q.as_bytes()).map(|(u, v)| (u & v).count_ones()).sum::<u32>();
+        ret as f32
+    }
+}
+
+#[inline]
+pub fn hamming_bitwise_fast(u: &[u8], v: &[u8]) -> f32 {
+    // based on : https://github.com/emschwartz/hamming-bitwise-fast
+    // Explicitly structuring the code as below lends itself to SIMD optimizations by
+    // the compiler -> https://matklad.github.io/2023/04/09/can-you-trust-a-compiler-to-optimize-your-code.html
+    assert_eq!(u.len(), v.len());
+
+    type BitPackedWord = u64;
+    const CHUNK_SIZE: usize = std::mem::size_of::<BitPackedWord>();
+
+    let mut distance = u
+        .chunks_exact(CHUNK_SIZE)
+        .zip(v.chunks_exact(CHUNK_SIZE))
+        .map(|(u_chunk, v_chunk)| {
+            let u_val = BitPackedWord::from_ne_bytes(u_chunk.try_into().unwrap());
+            let v_val = BitPackedWord::from_ne_bytes(v_chunk.try_into().unwrap());
+            (u_val ^ v_val).count_ones()
+        })
+        .sum::<u32>();
+
+    if u.len() % CHUNK_SIZE != 0 {
+        distance += u
+            .chunks_exact(CHUNK_SIZE)
+            .remainder()
+            .iter()
+            .zip(v.chunks_exact(CHUNK_SIZE).remainder())
+            .map(|(u_byte, v_byte)| (u_byte ^ v_byte).count_ones())
+            .sum::<u32>();
+    }
+
+    distance as f32
+}

--- a/src/distance/mod.rs
+++ b/src/distance/mod.rs
@@ -15,6 +15,7 @@ pub use euclidean::{Euclidean, NodeHeaderEuclidean};
 use heed::{RwPrefix, RwTxn};
 pub use manhattan::{Manhattan, NodeHeaderManhattan};
 use rand::Rng;
+pub use hamming::{Hamming, NodeHeaderHamming};
 
 use crate::internals::{KeyCodec, Side};
 use crate::node::Leaf;
@@ -29,6 +30,7 @@ mod cosine;
 mod dot_product;
 mod euclidean;
 mod manhattan;
+mod hamming;
 
 fn new_leaf<D: Distance>(vec: Vec<f32>) -> Leaf<'static, D> {
     let vector = UnalignedVector::from_vec(vec);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub mod internals {
     pub use crate::distance::{
         NodeHeaderBinaryQuantizedCosine, NodeHeaderBinaryQuantizedEuclidean,
         NodeHeaderBinaryQuantizedManhattan, NodeHeaderCosine, NodeHeaderDotProduct,
-        NodeHeaderEuclidean, NodeHeaderManhattan,
+        NodeHeaderEuclidean, NodeHeaderManhattan, NodeHeaderHamming
     };
     pub use crate::key::KeyCodec;
     pub use crate::node::{Leaf, NodeCodec};
@@ -145,7 +145,7 @@ pub mod internals {
 pub mod distances {
     pub use crate::distance::{
         BinaryQuantizedCosine, BinaryQuantizedEuclidean, BinaryQuantizedManhattan, Cosine,
-        DotProduct, Euclidean, Manhattan,
+        DotProduct, Euclidean, Manhattan, Hamming
     };
 }
 

--- a/src/tests/binary.rs
+++ b/src/tests/binary.rs
@@ -1,0 +1,55 @@
+use crate::{
+    distance::Hamming,
+    tests::{create_database, rng},
+    Writer,
+};
+
+#[test]
+fn write_and_retrieve_binary_vector() {
+    let handle = create_database::<Hamming>();
+    let mut wtxn = handle.env.write_txn().unwrap();
+    let writer = Writer::new(handle.database, 0, 16);
+    writer
+        .add_item(
+            &mut wtxn,
+            0,
+            &[
+                -2.0, -1.0, 0.0, -0.1, 2.0, 2.0, -12.4, 21.2, -2.0, -1.0, 0.0, 1.0, 2.0, 2.0,
+                -12.4, 21.2,
+            ],
+        )
+        .unwrap();
+    let vec = writer.item_vector(&wtxn, 0).unwrap().unwrap();
+    insta::assert_debug_snapshot!(vec, @r###"
+    [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+        1.0,
+        0.0,
+        1.0,
+    ]
+    "###);
+
+    writer.builder(&mut rng()).n_trees(1).build(&mut wtxn).unwrap();
+    wtxn.commit().unwrap();
+
+    insta::assert_snapshot!(handle, @r###"
+    ==================
+    Dumping index 0
+    Root: Metadata { dimensions: 16, items: RoaringBitmap<[0]>, roots: [0], distance: "hamming" }
+    Version: Version { major: 0, minor: 6, patch: 1 }
+    Tree 0: Descendants(Descendants { descendants: [0] })
+    Item 0: Leaf(Leaf { header: NodeHeaderHamming, vector: [0.0000, 0.0000, 0.0000, 0.0000, 1.0000, 1.0000, 0.0000, 1.0000, 0.0000, 0.0000, "other ..."] })
+    "###);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,6 +9,7 @@ use tempfile::TempDir;
 use crate::version::VersionCodec;
 use crate::{Database, Distance, MetadataCodec, NodeCodec, NodeMode, Reader};
 
+mod binary;
 mod binary_quantized;
 mod reader;
 mod writer;

--- a/src/unaligned_vector/binary.rs
+++ b/src/unaligned_vector/binary.rs
@@ -1,0 +1,257 @@
+use std::borrow::Cow;
+use std::mem::transmute;
+use std::slice::ChunksExact;
+
+use super::{SizeMismatch, UnalignedVector, UnalignedVectorCodec};
+
+/// The type of the words used to quantize a vector
+type BitPackedWord = u64;
+/// The size of the words used to quantize a vector
+const PACKED_WORD_BITS: usize = BitPackedWord::BITS as usize;
+/// The number of bytes composing a Word
+const PACKED_WORD_BYTES: usize = std::mem::size_of::<BitPackedWord>();
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Binary {}
+
+impl UnalignedVectorCodec for Binary {
+    fn from_bytes(bytes: &[u8]) -> Result<Cow<UnalignedVector<Self>>, SizeMismatch> {
+        let rem = bytes.len() % PACKED_WORD_BYTES;
+        if rem == 0 {
+            // safety: `UnalignedVector` is transparent
+            Ok(Cow::Borrowed(unsafe { transmute::<&[u8], &UnalignedVector<Self>>(bytes) }))
+        } else {
+            Err(SizeMismatch { vector_codec: "binary quantized", rem })
+        }
+    }
+
+    fn from_slice(slice: &[f32]) -> Cow<'static, UnalignedVector<Self>> {
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") {
+                return Cow::Owned(unsafe { from_slice_neon(slice) });
+            }
+        }
+        Cow::Owned(from_slice_non_optimized(slice))
+    }
+
+    fn from_vec(vec: Vec<f32>) -> Cow<'static, UnalignedVector<Self>> {
+        Cow::Owned(Self::from_slice(&vec).into_owned())
+    }
+
+    fn to_vec(vec: &UnalignedVector<Self>) -> Vec<f32> {
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") {
+                return unsafe { to_vec_neon(vec) };
+            }
+        }
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("sse") {
+                return unsafe { to_vec_sse(vec) };
+            }
+        }
+        to_vec_non_optimized(vec)
+    }
+
+    fn iter(vec: &UnalignedVector<Self>) -> impl ExactSizeIterator<Item = f32> + '_ {
+        BinaryIterator {
+            current_element: 0,
+            // Force the pulling of the first word
+            current_iteration: PACKED_WORD_BITS,
+            iter: vec.vector.chunks_exact(PACKED_WORD_BYTES),
+        }
+    }
+
+    fn len(vec: &UnalignedVector<Self>) -> usize {
+        (vec.vector.len() / PACKED_WORD_BYTES) * PACKED_WORD_BITS
+    }
+
+    fn is_zero(vec: &UnalignedVector<Self>) -> bool {
+        vec.as_bytes().iter().all(|b| *b == 0)
+    }
+}
+
+pub(super) fn from_slice_non_optimized(slice: &[f32]) -> Vec<u8> {
+    let mut output = Vec::with_capacity((slice.len() + PACKED_WORD_BITS - 1) / PACKED_WORD_BITS);
+    for chunk in slice.chunks(PACKED_WORD_BITS) {
+        let mut word: BitPackedWord = 0;
+        let mut bits: u32;
+        for scalar in chunk.iter().rev() {
+            word <<= 1;
+            bits = scalar.to_bits();
+            // scalar>0.0_f32 => 1 else 0
+            word += (bits < 0x8000_0000 && bits > 0x0000_0000) as BitPackedWord;
+        }
+        output.extend_from_slice(&word.to_ne_bytes()); //  u64 into [u8;8] ?
+    }
+    output
+}
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+unsafe fn from_slice_neon(slice: &[f32]) -> Vec<u8> {
+    use core::arch::aarch64::*;
+
+    let iterations = slice.len() / PACKED_WORD_BYTES;
+    // The size of the returned vector must be a multiple of a word
+    let remaining = slice.len() % PACKED_WORD_BYTES;
+    let mut len = iterations;
+    if len % PACKED_WORD_BYTES != 0 {
+        len += PACKED_WORD_BYTES - len % PACKED_WORD_BYTES;
+    } else if remaining != 0 {
+        // if we generated a valid number of Word but we're missing a few bits
+        // then we need to add a full Word at the end.
+        len += PACKED_WORD_BYTES;
+    }
+    let mut ret = vec![0; len];
+    let ptr = slice.as_ptr();
+
+    let low: [u32; 4] = [
+        0b_00000000_00000000_00000000_00000001,
+        0b_00000000_00000000_00000000_00000010,
+        0b_00000000_00000000_00000000_00000100,
+        0b_00000000_00000000_00000000_00001000,
+    ];
+    let high: [u32; 4] = [
+        0b_00000000_00000000_00000000_00010000,
+        0b_00000000_00000000_00000000_00100000,
+        0b_00000000_00000000_00000000_01000000,
+        0b_00000000_00000000_00000000_10000000,
+    ];
+
+    for i in 0..iterations {
+        unsafe {
+            let mut byte = 0;
+            for (idx, mask) in [low, high].iter().enumerate() {
+                let lane = vld1q_f32(ptr.add(i * 8 + 4 * idx));
+                let lane = vcgtzq_f32(lane);
+                let mask = vld1q_u32(mask.as_ptr());
+                let lane = vandq_u32(lane, mask);
+
+                byte |= vaddvq_u32(lane) as u8;
+            }
+            *ret.get_unchecked_mut(i) = byte;
+        }
+    }
+
+    // Since we're iterating on bytes two by two.
+    // If we had a number of dimensions not dividible by 8 we may be
+    // missing some bits in the last byte.
+    if remaining != 0 {
+        let mut rem: u8 = 0;
+        let mut bits: u32;
+        for r in slice[slice.len() - remaining..].iter().rev() {
+            rem <<= 1;
+            bits = r.to_bits();
+            let r = (bits < 0x8000_0000 && bits > 0x0000_0000);
+            rem |= r as u8;
+        }
+        ret[iterations] = rem;
+    }
+
+    ret
+}
+
+pub(super) fn to_vec_non_optimized(vec: &UnalignedVector<Binary>) -> Vec<f32> {
+    vec.iter().collect()
+}
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+unsafe fn to_vec_neon(vec: &UnalignedVector<Binary>) -> Vec<f32> {
+    use core::arch::aarch64::*;
+
+    let mut output: Vec<f32> = vec![0.0; vec.len()];
+    let output_ptr = output.as_mut_ptr();
+    let bytes = vec.as_bytes();
+    let low_mask = [0b_0000_0001, 0b_0000_0010, 0b_0000_0100, 0b_0000_1000];
+    let high_mask = [0b_0001_0000, 0b_0010_0000, 0b_0100_0000, 0b_1000_0000];
+    let ones = unsafe { vld1q_dup_f32(&1.0) };
+    let minus = unsafe { vld1q_dup_f32(&-1.0) };
+
+    for (current_byte, base) in bytes.iter().enumerate() {
+        unsafe {
+            let base = *base as u32;
+            let base = vld1q_dup_u32(&base);
+            for (i, mask) in [low_mask, high_mask].iter().enumerate() {
+                let mask = vld1q_u32(mask.as_ptr());
+                let mask = vandq_u32(base, mask);
+                // 0xffffffff if equal to zero and 0x00000000 otherwise
+                let mask = vceqzq_u32(mask);
+                let lane = vbslq_f32(mask, minus, ones);
+                let offset = output_ptr.add(current_byte * 8 + i * 4);
+                vst1q_f32(offset, lane);
+            }
+        }
+    }
+
+    output
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+unsafe fn to_vec_sse(vec: &UnalignedVector<Binary>) -> Vec<f32> {
+    use core::arch::x86_64::*;
+
+    let mut output: Vec<f32> = vec![0.0; vec.len()];
+    let output_ptr = output.as_mut_ptr();
+    let bytes = vec.as_bytes();
+    let low_mask = [0b_0000_0001, 0b_0000_0010, 0b_0000_0100, 0b_0000_1000];
+    let high_mask = [0b_0001_0000, 0b_0010_0000, 0b_0100_0000, 0b_1000_0000];
+    let ones = unsafe { _mm_set1_ps(1.0) };
+
+    for (current_byte, base) in bytes.iter().enumerate() {
+        unsafe {
+            let base = _mm_set1_epi32(*base as i32);
+            for (i, mask) in [low_mask, high_mask].iter().enumerate() {
+                let mask = _mm_set_epi32(mask[3], mask[2], mask[1], mask[0]);
+                let mask = _mm_and_si128(base, mask);
+                // 0xffffffff if equal to zero and 0x00000000 otherwise
+                let mask = _mm_cmpeq_epi32(mask, _mm_setzero_si128());
+                let lane = _mm_blendv_ps(ones, _mm_setzero_ps(), _mm_castsi128_ps(mask));
+                let offset = output_ptr.add(current_byte * 8 + i * 4);
+                _mm_store_ps(offset, lane);
+            }
+        }
+    }
+
+    output
+}
+
+pub struct BinaryIterator<'a> {
+    current_element: BitPackedWord,
+    current_iteration: usize,
+    iter: ChunksExact<'a, u8>,
+}
+
+impl Iterator for BinaryIterator<'_> {
+    type Item = f32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_iteration >= PACKED_WORD_BITS {
+            let bytes = self.iter.next()?;
+            self.current_element = BitPackedWord::from_ne_bytes(bytes.try_into().unwrap());
+            self.current_iteration = 0;
+        }
+
+        let bit = self.current_element & 1;
+        self.current_element >>= 1;
+        self.current_iteration += 1;
+
+        Some(bit as f32)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (low, high) = self.iter.size_hint();
+        let rem = PACKED_WORD_BITS - self.current_iteration;
+
+        (low * PACKED_WORD_BITS + rem, high.map(|h| h * PACKED_WORD_BITS + rem))
+    }
+}
+
+impl ExactSizeIterator for BinaryIterator<'_> {
+    fn len(&self) -> usize {
+        let (lower, upper) = self.size_hint();
+        debug_assert_eq!(upper, Some(lower));
+        lower
+    }
+}

--- a/src/unaligned_vector/binary.rs
+++ b/src/unaligned_vector/binary.rs
@@ -81,10 +81,10 @@ pub(super) fn from_slice_non_optimized(slice: &[f32]) -> Vec<u8> {
         for scalar in chunk.iter().rev() {
             word <<= 1;
             bits = scalar.to_bits();
-            // scalar>0.0_f32 => 1 else 0
+            // scalar > 0.0 => 1, otherwise 0
             word += (bits < 0x8000_0000 && bits > 0x0000_0000) as BitPackedWord;
         }
-        output.extend_from_slice(&word.to_ne_bytes()); //  u64 into [u8;8] ?
+        output.extend_from_slice(&word.to_ne_bytes());
     }
     output
 }

--- a/src/unaligned_vector/binary_test.rs
+++ b/src/unaligned_vector/binary_test.rs
@@ -1,0 +1,189 @@
+#![allow(clippy::format_collect)]
+
+use binary::{from_slice_non_optimized, to_vec_non_optimized};
+use insta::{assert_debug_snapshot, assert_snapshot};
+use proptest::collection::vec;
+use proptest::prelude::*;
+
+use super::*;
+use crate::internals::UnalignedVectorCodec;
+
+#[test]
+fn test_from_slice() {
+    let original = [0.1, 0.2, -0.3, 0.4, -0.5, 0.6, -0.7, 0.8, -0.9];
+    let vector = Binary::from_slice(&original);
+
+    let internal = vector.as_bytes().iter().map(|b| format!("{b:08b}\n")).collect::<String>();
+    assert_snapshot!(internal, @r###"
+        10101011
+        00000000
+        00000000
+        00000000
+        00000000
+        00000000
+        00000000
+        00000000
+        "###);
+}
+
+#[test]
+fn test_to_vec_iter() {
+    let original = [0.1, 0.2, -0.3, 0.4, -0.5, 0.6, -0.7, 0.8, -0.9];
+    let vector = Binary::from_slice(&original);
+    let iter_vec: Vec<_> = Binary::iter(&vector).take(original.len()).collect();
+    assert_debug_snapshot!(iter_vec, @r###"
+        [
+            1.0,
+            1.0,
+            0.0,
+            1.0,
+            0.0,
+            1.0,
+            0.0,
+            1.0,
+            0.0,
+        ]
+        "###);
+    let mut vec_vec: Vec<_> = Binary::to_vec(&vector);
+    vec_vec.truncate(original.len());
+    assert_debug_snapshot!(vec_vec, @r###"
+        [
+            1.0,
+            1.0,
+            0.0,
+            1.0,
+            0.0,
+            1.0,
+            0.0,
+            1.0,
+            0.0,
+        ]
+        "###);
+
+    assert_eq!(vec_vec, iter_vec);
+}
+
+#[test]
+fn unaligned_f32_vec() {
+    let original: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let bytes: Vec<u8> = original.iter().flat_map(|f| f.to_ne_bytes()).collect();
+
+    let unaligned_owned_from_f32 = UnalignedVector::<f32>::from_vec(original.clone());
+    assert_eq!(bytes, unaligned_owned_from_f32.as_bytes());
+
+    let unchecked_unaligned_owned_from_bytes = UnalignedVector::<f32>::from_bytes_unchecked(&bytes);
+    assert_eq!(bytes, unchecked_unaligned_owned_from_bytes.as_bytes());
+
+    let unaligned_owned_from_bytes = UnalignedVector::<f32>::from_bytes(&bytes).unwrap();
+    assert_eq!(bytes, unaligned_owned_from_bytes.as_bytes());
+}
+
+#[test]
+fn unaligned_binary_quantized_iter_size() {
+    let original: Vec<f32> = vec![-1.0, 2.0, -3.0, 4.0, 5.0];
+    let unaligned = UnalignedVector::<Binary>::from_slice(&original);
+    assert_snapshot!(unaligned.len(), @"64");
+    let mut iter = unaligned.iter();
+    assert_snapshot!(iter.len(), @"64");
+    iter.next().unwrap();
+    assert_snapshot!(iter.len(), @"63");
+    iter.by_ref().take(10).for_each(drop);
+    assert_snapshot!(iter.len(), @"53");
+    iter.by_ref().take(52).for_each(drop);
+    assert_snapshot!(iter.len(), @"1");
+    iter.next().unwrap();
+    assert_snapshot!(iter.len(), @"0");
+    iter.next();
+    assert_snapshot!(iter.len(), @"0");
+}
+
+#[test]
+fn unaligned_binary_quantized_smol() {
+    let original: Vec<f32> = vec![-1.0, 2.0, -3.0, 4.0, 5.0];
+
+    let unaligned = UnalignedVector::<Binary>::from_slice(&original);
+    let s = unaligned.as_bytes().iter().map(|byte| format!("{byte:08b}\n")).collect::<String>();
+    assert_snapshot!(s, @r###"
+    00011010
+    00000000
+    00000000
+    00000000
+    00000000
+    00000000
+    00000000
+    00000000
+    "###);
+
+    let deser: Vec<_> = unaligned.iter().collect();
+    assert_debug_snapshot!(deser[0..original.len()], @r###"
+    [
+        0.0,
+        1.0,
+        0.0,
+        1.0,
+        1.0,
+    ]
+    "###);
+}
+
+#[test]
+fn unaligned_binary_quantized_large() {
+    let original: Vec<f32> =
+        (0..100).map(|n| if n % 3 == 0 || n % 5 == 0 { -1.0 } else { 1.0 }).collect();
+
+    // Two numbers should be used
+    let unaligned = UnalignedVector::<Binary>::from_slice(&original);
+    let s = unaligned.as_bytes().iter().map(|byte| format!("{byte:08b}\n")).collect::<String>();
+    assert_snapshot!(s, @r###"
+    10010110
+    01101001
+    11001011
+    10110100
+    01100101
+    11011010
+    00110010
+    01101101
+    10011001
+    10110110
+    01001100
+    01011011
+    00000110
+    00000000
+    00000000
+    00000000
+    "###);
+
+    let deser: Vec<_> = unaligned.to_vec();
+    assert_snapshot!(format!("{:?}", &deser[0..original.len()]),
+    @"[0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0]");
+    for (orig, deser) in original.iter().zip(&deser) {
+        if orig.is_sign_positive() {
+            assert_eq!(deser, &1.0, "Expected 1 but found {deser}");
+        } else {
+            assert_eq!(deser, &0.0, "Expected 0 but found {deser}");
+        }
+    }
+}
+
+proptest! {
+    #[test]
+    fn from_slice_simd_vs_non_optimized(
+        original in vec(-50f32..=50.2, 0..516)
+    ){
+        let vector = Binary::from_slice(&original);
+        let iter_vec: Vec<_> = to_vec_non_optimized(&vector);
+        let vec_vec: Vec<_> = Binary::to_vec(&vector);
+
+        assert_eq!(vec_vec, iter_vec);
+    }
+
+    #[test]
+    fn to_vec_simd_vs_non_optimized(
+        original in vec(-50f32..=50.2, 0..516)
+    ){
+        let vector1 = Binary::from_slice(&original);
+        let vector2 = from_slice_non_optimized(&original);
+
+        assert_eq!(vector1.as_bytes(), &vector2);
+    }
+}

--- a/src/unaligned_vector/binary_test.rs
+++ b/src/unaligned_vector/binary_test.rs
@@ -28,13 +28,13 @@ fn test_from_slice() {
 
 #[test]
 fn test_to_vec_iter() {
-    let original = [0.1, 0.2, -0.3, 0.4, -0.5, 0.6, -0.7, 0.8, -0.9];
+    let original = [0.1, 0.0, -0.3, 0.4, -0.5, 0.6, -0.7, 0.8, -0.9];
     let vector = Binary::from_slice(&original);
     let iter_vec: Vec<_> = Binary::iter(&vector).take(original.len()).collect();
     assert_debug_snapshot!(iter_vec, @r###"
         [
             1.0,
-            1.0,
+            0.0,
             0.0,
             1.0,
             0.0,
@@ -49,7 +49,7 @@ fn test_to_vec_iter() {
     assert_debug_snapshot!(vec_vec, @r###"
         [
             1.0,
-            1.0,
+            0.0,
             0.0,
             1.0,
             0.0,

--- a/src/unaligned_vector/mod.rs
+++ b/src/unaligned_vector/mod.rs
@@ -6,14 +6,19 @@ use std::{
 };
 
 pub use binary_quantized::BinaryQuantized;
+pub use binary::Binary;
 
 use bytemuck::pod_collect_to_vec;
 
 mod binary_quantized;
+mod binary;
 mod f32;
 
 #[cfg(test)]
 mod binary_quantized_test;
+
+#[cfg(test)]
+mod binary_test;
 
 /// Determine the way the vectors should be read and written from the database
 pub trait UnalignedVectorCodec: std::borrow::ToOwned + Sized {


### PR DESCRIPTION
# Pull Request
Had some time this weekend and wanted to try to incorporate hamming into arroy ! 

Check comments in the PR to explain some of the logic 

## Related issue
Fixes #102 

## What does this PR do?
- Adds `Hamming` distance and a new {0,1}-quantized `UnalignedVectorCodec` impl for binary strings
- Updates corresponding SIMD instructions for binary ops 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
