### PR TITLE
Update rustc to 1.82

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: dtolnay/rust-toolchain@1.81
+      - uses: dtolnay/rust-toolchain@1.82
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: dtolnay/rust-toolchain@1.81
+      - uses: dtolnay/rust-toolchain@1.82
         with:
           profile: minimal
           components: clippy, rustfmt


### PR DESCRIPTION
The CI cannot run on main currently because a dependency of the lib has updated the minimum msrv it looks like: https://github.com/meilisearch/arroy/actions/runs/15047907250/job/42295060151?pr=125