### PR TITLE
Make splitnode only refers to tree nodes

### DIFF
--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -489,13 +489,8 @@ impl<'t, D: Distance> ImmutableTrees<'t, D> {
                 }
                 Node::SplitPlaneNormal(SplitPlaneNormal { left, right, normal: _ }) => {
                     trees.insert(current, (bytes.len(), bytes.as_ptr()));
-                    // We must avoid the items and only push the tree nodes
-                    if left.mode == NodeMode::Tree {
-                        explore.push(left.item);
-                    }
-                    if right.mode == NodeMode::Tree {
-                        explore.push(right.item);
-                    }
+                    explore.push(left);
+                    explore.push(right);
                 }
             }
         }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/arroy/issues/119

## What does this PR do?
- Update the codec of splitnodes to not contain items
- Simplify all the writer+parallel code with this new assumption (a lot of matches and ifs can be removed)