### PR TITLE
Remove a first batch of useless writes to tmp files and LMDB

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -40,8 +40,15 @@ impl<'a, D: Distance> Node<'a, D> {
             None
         }
     }
-}
 
+    pub fn descendants(self) -> Option<Descendants<'a>> {
+        if let Node::Descendants(descendants) = self {
+            Some(descendants)
+        } else {
+            None
+        }
+    }
+}
 /// A leaf node which corresponds to the vector inputed
 /// by the user and the distance header.
 pub struct Leaf<'a, D: Distance> {


### PR DESCRIPTION
After reducing the number of writes we do to LMDB, here's a view of where the time is lost during an indexing process.

![image](https://github.com/user-attachments/assets/5cb87d1d-e0e9-4df5-8139-c4b93a8d962e)

- 47% of the time is spent in building the tree. In this function, almost all the time is spent on computing the Cosine distance. We can't really optimize that more, but it's the part we could multi-thread in the future.
- 27% of the time is spent refreshing our leaves after a write to LMDB. That's also synchronization points where we cannot properly multi-thread
- An additional 4.5%+2.1% are lost creating and removing TmpFile during the loop

In this PR, I'll get rid of all the writes we do in LMDB and instead read my own `TmpFile`.
That means we don't have to refresh the leaves anymore, saving 27% of the time. Probably also the 6% creating and removing temp files, as we could only have one per thread instead.

That should also open the way to better parallelization later on as we won't have any common state between the threads. Only the queue of large descendants to explode will be shared behind a mutex where each thread can pop and push I guess 🤔 