### PR TITLE
Introduce the `Writer::prepare_for_conversion` method

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release-v0.6"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release-v0.6"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: dtolnay/rust-toolchain@1.81
+      - uses: dtolnay/rust-toolchain@1.85
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: dtolnay/rust-toolchain@1.81
+      - uses: dtolnay/rust-toolchain@1.85
         with:
           profile: minimal
           components: clippy, rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ anyhow = "1.0.95"
 arbitrary = { version = "1.4.1", features = ["derive"] }
 clap = { version = "4.5.24", features = ["derive"] }
 env_logger = "0.11.6"
+hannoy = "0.0.4"
 insta = "1.42.0"
 instant-distance = "0.6.1"
 proptest = "1.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "arroy"
 description = "Annoy-inspired Approximate Nearest Neighbors in Rust, based on LMDB and optimized for memory usage"
-version = "0.6.2"
+version = "0.6.3"
 documentation = "https://docs.rs/arroy"
 repository = "https://github.com/meilisearch/arroy"
 keywords = ["ANN-search", "Graph-algorithms", "Vector-Search", "Store"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ enum-iterator = "2.1.0"
 
 [dev-dependencies]
 anyhow = "1.0.95"
+approx = "0.5.1"
 arbitrary = { version = "1.4.1", features = ["derive"] }
 clap = { version = "4.5.24", features = ["derive"] }
 env_logger = "0.11.6"

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -321,7 +321,7 @@ impl<'t, D: Distance> Reader<'t, D> {
                     let key = Key::new(self.index, item);
                     match self.database.get(rtxn, &key)?.ok_or(Error::missing_key(key))? {
                         Node::Leaf(_) => {
-                            if opt.candidates.map_or(true, |c| c.contains(item.item)) {
+                            if opt.candidates.is_none_or(|c| c.contains(item.item)) {
                                 nns.push(item.unwrap_item());
                             }
                         }

--- a/src/tests/binary_quantized.rs
+++ b/src/tests/binary_quantized.rs
@@ -44,12 +44,12 @@ fn write_and_retrieve_binary_quantized_vector() {
     writer.builder(&mut rng()).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 16, items: RoaringBitmap<[0]>, roots: [0], distance: "binary quantized euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderBinaryQuantizedEuclidean { bias: 0.0 }, vector: [-1.0000, -1.0000, 1.0000, -1.0000, 1.0000, 1.0000, -1.0000, 1.0000, -1.0000, -1.0000, "other ..."] })
-    "#);
+    "###);
 }

--- a/src/tests/writer.rs
+++ b/src/tests/writer.rs
@@ -110,14 +110,14 @@ fn use_u32_max_minus_one_for_a_vec() {
     writer.builder(&mut rng()).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[4294967294]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [4294967294] })
     Item 4294967294: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -130,14 +130,14 @@ fn use_u32_max_for_a_vec() {
     writer.builder(&mut rng()).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[4294967295]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [4294967295] })
     Item 4294967295: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -150,14 +150,14 @@ fn write_one_vector() {
     writer.builder(&mut rng()).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -170,14 +170,14 @@ fn write_one_vector_in_one_tree() {
     writer.builder(&mut rng()).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -190,14 +190,14 @@ fn write_one_vector_in_multiple_trees() {
     writer.builder(&mut rng()).n_trees(10).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -214,16 +214,16 @@ fn write_vectors_until_there_is_a_descendants() {
     writer.builder(&mut rng()).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0, 1, 2]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0, 1, 2] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000, 0.0000] })
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [1.0000, 1.0000, 1.0000] })
     Item 2: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [2.0000, 2.0000, 2.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -292,38 +292,38 @@ fn write_multiple_indexes() {
     }
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     ==================
     Dumping index 1
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     ==================
     Dumping index 2
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     ==================
     Dumping index 3
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
     ==================
     Dumping index 4
     Root: Metadata { dimensions: 3, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 1.0000, 2.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -416,14 +416,14 @@ fn delete_one_item_in_a_one_item_db() {
     writer.builder(&mut rng).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
-    "#);
+    "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
     let writer = Writer::new(handle.database, 0, 2);
@@ -433,12 +433,12 @@ fn delete_one_item_in_a_one_item_db() {
     writer.builder(&mut rng).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[]>, roots: [], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
-    "#);
+    Version: Version { major: 0, minor: 6, patch: 3 }
+    "###);
 
     let rtxn = handle.env.read_txn().unwrap();
     let one_reader = Reader::open(&rtxn, 0, handle.database).unwrap();
@@ -459,14 +459,14 @@ fn delete_document_in_an_empty_index_74() {
 
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
-    "#);
+    "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
 
@@ -485,16 +485,16 @@ fn delete_document_in_an_empty_index_74() {
 
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[]>, roots: [], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     ==================
     Dumping index 1
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[]>, roots: [], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
-    "#);
+    Version: Version { major: 0, minor: 6, patch: 3 }
+    "###);
 
     let rtxn = handle.env.read_txn().unwrap();
     let reader = Reader::open(&rtxn, 1, handle.database).unwrap();
@@ -515,15 +515,15 @@ fn delete_one_item_in_a_descendant() {
     writer.builder(&mut rng).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0, 1] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [1.0000, 0.0000] })
-    "#);
+    "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
     let writer = Writer::new(handle.database, 0, 2);
@@ -533,14 +533,14 @@ fn delete_one_item_in_a_descendant() {
     writer.builder(&mut rng).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[1]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [1] })
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [1.0000, 0.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -577,15 +577,15 @@ fn delete_one_leaf_in_a_split() {
     wtxn.commit().unwrap();
 
     // after deleting the leaf, the split node should be replaced by a descendant
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[1, 2]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [1, 2] })
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [1.0000, 0.0000] })
     Item 2: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [2.0000, 0.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -600,14 +600,14 @@ fn delete_one_item_in_a_single_document_database() {
     writer.builder(&mut rng).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0]>, roots: [0], distance: "cosine" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderCosine { norm: 0.0 }, vector: [0.0000, 0.0000] })
-    "#);
+    "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
     let writer = Writer::new(handle.database, 0, 2);
@@ -617,12 +617,12 @@ fn delete_one_item_in_a_single_document_database() {
     writer.builder(&mut rng).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[]>, roots: [], distance: "cosine" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
-    "#);
+    Version: Version { major: 0, minor: 6, patch: 3 }
+    "###);
 }
 
 #[test]
@@ -711,12 +711,12 @@ fn add_one_item_incrementally_in_an_empty_db() {
     writer.builder(&mut rng).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[]>, roots: [], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
-    "#);
+    Version: Version { major: 0, minor: 6, patch: 3 }
+    "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
     let writer = Writer::new(handle.database, 0, 2);
@@ -724,14 +724,14 @@ fn add_one_item_incrementally_in_an_empty_db() {
     writer.builder(&mut rng).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -744,14 +744,14 @@ fn add_one_item_incrementally_in_a_one_item_db() {
     writer.builder(&mut rng).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
-    "#);
+    "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
     let writer = Writer::new(handle.database, 0, 2);
@@ -759,15 +759,15 @@ fn add_one_item_incrementally_in_a_one_item_db() {
     writer.builder(&mut rng).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0, 1] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [1.0000, 0.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -781,15 +781,15 @@ fn add_one_item_incrementally_to_create_a_split_node() {
     writer.builder(&mut rng).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0, 1] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [1.0000, 0.0000] })
-    "#);
+    "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
     let writer = Writer::new(handle.database, 0, 2);
@@ -797,17 +797,17 @@ fn add_one_item_incrementally_to_create_a_split_node() {
     writer.builder(&mut rng).n_trees(1).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
 
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 0
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1, 2]>, roots: [2], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 1: Descendants(Descendants { descendants: [1, 2] })
     Tree 2: SplitPlaneNormal(SplitPlaneNormal<euclidean> { left: Item(0), right: Tree(1), normal: [1.0000, 0.0000] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [1.0000, 0.0000] })
     Item 2: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [2.0000, 0.0000] })
-    "#);
+    "###);
 }
 
 #[test]
@@ -1108,15 +1108,15 @@ fn append() {
     assert_snapshot!(err, @"Item cannot be appended into the database");
     writer.builder(&mut rng).build(&mut wtxn).unwrap();
     wtxn.commit().unwrap();
-    insta::assert_snapshot!(handle, @r#"
+    insta::assert_snapshot!(handle, @r###"
     ==================
     Dumping index 1
     Root: Metadata { dimensions: 2, items: RoaringBitmap<[0, 1]>, roots: [0], distance: "euclidean" }
-    Version: Version { major: 0, minor: 6, patch: 2 }
+    Version: Version { major: 0, minor: 6, patch: 3 }
     Tree 0: Descendants(Descendants { descendants: [0, 1] })
     Item 0: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.0000, 0.0000] })
     Item 1: Leaf(Leaf { header: NodeHeaderEuclidean { bias: 0.0 }, vector: [0.1000, 0.1000] })
-    "#);
+    "###);
 
     let mut wtxn = handle.env.write_txn().unwrap();
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use heed::types::{Bytes, DecodeIgnore, Unit};
 use heed::{MdbError, PutFlags, RoTxn, RwTxn};
 use rand::{Rng, SeedableRng};
-use rayon::iter::repeatn;
+use rayon::iter::repeat_n;
 use rayon::prelude::*;
 use roaring::RoaringBitmap;
 
@@ -816,7 +816,7 @@ impl<D: Distance> Writer<D> {
     ) -> Result<(Vec<ItemId>, Vec<TmpNodesReader>)> {
         let roots: Vec<_> = metadata.roots.iter().collect();
 
-        repeatn(rng.next_u64(), metadata.roots.len())
+        repeat_n(rng.next_u64(), metadata.roots.len())
             .zip(roots)
             .map(|(seed, root)| {
                 tracing::debug!("started updating tree {root:X}...");
@@ -1042,7 +1042,7 @@ impl<D: Distance> Writer<D> {
         let n_items = item_indices.len();
         let concurrent_node_ids = frozen_reader.concurrent_node_ids;
 
-        repeatn(rng.next_u64(), n_trees.unwrap_or(usize::MAX))
+        repeat_n(rng.next_u64(), n_trees.unwrap_or(usize::MAX))
             .enumerate()
             // Stop generating trees once the specified number of tree nodes are generated
             // but continue to generate trees if the number of trees is unspecified

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -245,6 +245,7 @@ impl<'a, D: Distance, R: Rng + SeedableRng> ArroyBuilder<'a, D, R> {
         self.writer.build(wtxn, self.rng, &self.inner)
     }
 
+    /// Prepares the conversion from an hannoy database into an arroy one.
     pub fn prepare_hannoy_conversion(&self, wtxn: &mut RwTxn) -> Result<()> {
         self.writer.prepare_hannoy_conversion(wtxn, &self.inner)
     }


### PR DESCRIPTION
This PR is akin to https://github.com/nnethercott/hannoy/pull/42 and introduces a way to convert a hannoy database into an arroy one. We plan to add an (experimental) setting in the index settings of Meilisearch that permits users to switch between Vector Store backends.