### PR TITLE
Use a classic macos machine

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest-xlarge, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust:
           - stable
           - beta


### PR DESCRIPTION
Related to #154.

Update the macOS CI machines to use standard, free machines instead of large, paid ones.